### PR TITLE
rtl/vproc_alu: fix vaadd RNE, ROD rounding modes

### DIFF
--- a/rtl/vproc_alu.sv
+++ b/rtl/vproc_alu.sv
@@ -228,13 +228,15 @@ module vproc_alu #(
                 // the result if the bit that is shifted out was set.
                 unique case (pipe_in_ctrl_i.vxrm)
                     // round-to-nearest-up: always carry in
-                    VXRM_RNU: carry_in_mask[i] =  operand1_9bpb[9*i] | operand2_9bpb[9*i];
+                    VXRM_RNU: carry_in_mask[i] = operand1_9bpb[9*i] | operand2_9bpb[9*i];
                     // round-to-nearest-even: carry in if the shifted result (w/o carry) would be odd
-                    VXRM_RNE: carry_in_mask[i] = (operand1_9bpb[9*i] | operand2_9bpb[9*i]) & (operand1_9bpb[9*i+1] != operand2_9bpb[9*i+1]);
+                    VXRM_RNE: carry_in_mask[i] = (operand1_9bpb[9*i] & operand2_9bpb[9*i]) | 
+                                                 ((operand1_9bpb[9*i] ^ operand2_9bpb[9*i]) & (operand1_9bpb[9*i+1] != operand2_9bpb[9*i+1]));
                     // round-down: no carry in
-                    VXRM_RDN: carry_in_mask[i] =  operand1_9bpb[9*i] & operand2_9bpb[9*i];
+                    VXRM_RDN: carry_in_mask[i] = operand1_9bpb[9*i] & operand2_9bpb[9*i];
                     // round-to-odd: carry in if the shifted result (w/o carry) would be even
-                    VXRM_ROD: carry_in_mask[i] = (operand1_9bpb[9*i] | operand2_9bpb[9*i]) & (operand1_9bpb[9*i+1] == operand2_9bpb[9*i+1]);
+                    VXRM_ROD: carry_in_mask[i] = (operand1_9bpb[9*i] & operand2_9bpb[9*i]) | 
+                                                 ((operand1_9bpb[9*i] ^ operand2_9bpb[9*i]) & (operand1_9bpb[9*i+1] == operand2_9bpb[9*i+1]));
                     default: ;
                 endcase
             end


### PR DESCRIPTION
This PR fixes failing edge-case vaadd tests by fixing the rounding logic regarding RNE, ROD. According to tests when LSB is not lost after shifting (getting integer case), the integer shouldn't be rounded to even or odd forcefully. To avoid it, i have updated the logic of RNE and ROD to prevent rounding in some cases like 3+3 with RNE, 1+3 with ROD etc.