### PR TITLE
Fixes for vlox/vlux, vsox/vsux and vle16 instructions

### DIFF
--- a/rtl/vproc_decoder.sv
+++ b/rtl/vproc_decoder.sv
@@ -287,6 +287,9 @@ module vproc_decoder #(
                     end
                     2'b01,
                     2'b11: begin // indexed load/store
+
+                        // store data sew and lmul in alt signal
+                        // index sew and lmul are stored in eew and emul
                         mode_o.lsu.stride            = LSU_INDEXED;
                         mode_o.lsu.alt_eew           = vsew_i;
                         rs2_o.vreg                   = 1'b1;
@@ -2306,6 +2309,8 @@ module vproc_decoder #(
             endcase
             
             if(mode_o.lsu.stride == LSU_INDEXED) begin
+                // vl does not need to be scaled since for indexed stride
+                // we use default sew and lmul
             	vl_o = vl_i;
             end
             
@@ -2491,6 +2496,8 @@ module vproc_decoder #(
         endcase
 
         if(mode_o.lsu.stride == LSU_INDEXED) begin
+            // since for indexed stride we use the default lmul
+            // we need to adapt the mask 
             unique case (lmul_i)
                 LMUL_F8,
                 LMUL_F4,
@@ -2527,6 +2534,8 @@ module vproc_decoder #(
                 vd_invalid  = (instr_vd  & {2'b00, regaddr_mask       }) != 5'b0;
 
                 if(mode_o.lsu.stride == LSU_INDEXED) begin
+                    // since for indexed stride we use the default lmul
+                    // we use the adapted mask 
                     vd_invalid  = (instr_vd  & {2'b00, regaddr_mask_index_vd       }) != 5'b0;
                 end
             end

--- a/rtl/vproc_decoder.sv
+++ b/rtl/vproc_decoder.sv
@@ -287,9 +287,21 @@ module vproc_decoder #(
                     end
                     2'b01,
                     2'b11: begin // indexed load/store
-                        mode_o.lsu.stride = LSU_INDEXED;
-                        rs2_o.vreg        = 1'b1;
-                        rs2_o.r.vaddr     = instr_vs2;
+                        mode_o.lsu.stride            = LSU_INDEXED;
+                        mode_o.lsu.alt_eew           = vsew_i;
+                        rs2_o.vreg                   = 1'b1;
+                        rs2_o.r.vaddr                = instr_vs2;
+
+                        unique case (lmul_i)
+                            LMUL_F8,
+                            LMUL_F4,
+                            LMUL_F2,
+                            LMUL_1:  mode_o.lsu.alt_emul = EMUL_1;
+                            LMUL_2:  mode_o.lsu.alt_emul = EMUL_2;
+                            LMUL_4:  mode_o.lsu.alt_emul = EMUL_4;
+                            LMUL_8:  mode_o.lsu.alt_emul = EMUL_8;
+                            default: ;
+                        endcase
                     end
                     default: ;
                 endcase
@@ -2292,6 +2304,11 @@ module vproc_decoder #(
                 end
                 default: ;
             endcase
+            
+            if(mode_o.lsu.stride == LSU_INDEXED) begin
+            	vl_o = vl_i;
+            end
+            
         `ifdef RISCV_ZVE32F
 
         end else if (unit_o == UNIT_FPU) begin
@@ -2442,10 +2459,13 @@ module vproc_decoder #(
 
     // address masks (lower bits that must be 0) for registers based on EMUL:
     logic [2:0] regaddr_mask, regaddr_mask_narrow, regaddr_mask_narrow_x4;
+    logic [2:0] regaddr_mask_index_vd;
+
     always_comb begin
         regaddr_mask           = DONT_CARE_ZERO ? '0 : 'x;
         regaddr_mask_narrow    = DONT_CARE_ZERO ? '0 : 'x;
         regaddr_mask_narrow_x4 = DONT_CARE_ZERO ? '0 : 'x; //used for [s/z]ext.vf4
+        regaddr_mask_index_vd  = DONT_CARE_ZERO ? '0 : 'x;
         unique case (emul_o)
             EMUL_1: begin
                 regaddr_mask        = 3'b000;
@@ -2469,6 +2489,27 @@ module vproc_decoder #(
             end
             default: ;
         endcase
+
+        if(mode_o.lsu.stride == LSU_INDEXED) begin
+            unique case (lmul_i)
+                LMUL_F8,
+                LMUL_F4,
+                LMUL_F2,
+                LMUL_1: begin
+                    regaddr_mask_index_vd        = 3'b000;
+                end
+                LMUL_2: begin
+                    regaddr_mask_index_vd        = 3'b001;
+                end
+                LMUL_4: begin
+                    regaddr_mask_index_vd        = 3'b011;
+                end
+                LMUL_8: begin
+                    regaddr_mask_index_vd        = 3'b111;
+                end
+                default: ;
+            endcase
+        end
     end
 
     // check validity of register addresses:
@@ -2484,6 +2525,10 @@ module vproc_decoder #(
                 vs1_invalid = (instr_vs1 & {2'b00, regaddr_mask       }) != 5'b0;
                 vs2_invalid = (instr_vs2 & {2'b00, regaddr_mask       }) != 5'b0;
                 vd_invalid  = (instr_vd  & {2'b00, regaddr_mask       }) != 5'b0;
+
+                if(mode_o.lsu.stride == LSU_INDEXED) begin
+                    vd_invalid  = (instr_vd  & {2'b00, regaddr_mask_index_vd       }) != 5'b0;
+                end
             end
             OP_WIDENING: begin
                 vs1_invalid = (instr_vs1 & {2'b00, regaddr_mask_narrow}) != 5'b0;

--- a/rtl/vproc_lsu.sv
+++ b/rtl/vproc_lsu.sv
@@ -224,10 +224,10 @@ module vproc_lsu import vproc_pkg::*; #(
             ) : req_addr_q;
             LSU_INDEXED: begin
                 // note: the index is multiplied by the element byte width and the field count
-                unique case (pipe_in_ctrl_i.mode.lsu.eew)
-                    VSEW_8:  req_addr_d = pipe_in_ctrl_i.xval +  32'(vs2_data[7 :0]) * (32'(1) + 32'(pipe_in_ctrl_i.mode.lsu.nfields));
-                    VSEW_16: req_addr_d = pipe_in_ctrl_i.xval + {31'(vs2_data[15:0]) * (31'(1) + 31'(pipe_in_ctrl_i.mode.lsu.nfields)), 1'b0};
-                    VSEW_32: req_addr_d = pipe_in_ctrl_i.xval + {    vs2_data[29:0]  * (30'(1) + 30'(pipe_in_ctrl_i.mode.lsu.nfields)), 2'b0};
+                unique case (pipe_in_ctrl_i.mode.lsu.alt_eew)
+                    VSEW_8:  req_addr_d = pipe_in_ctrl_i.xval +  32'(vs2_data[7 :0]);//32'(vs2_data[7 :0]) * (32'(1) + 32'(pipe_in_ctrl_i.mode.lsu.nfields));
+                    VSEW_16: req_addr_d = pipe_in_ctrl_i.xval + 32'(vs2_data[15:0]);//{31'(vs2_data[15:0]) * (31'(1) + 31'(pipe_in_ctrl_i.mode.lsu.nfields)), 1'b0};
+                    VSEW_32: req_addr_d = pipe_in_ctrl_i.xval + 32'(vs2_data[31:0]);//{    vs2_data[29:0]  * (30'(1) + 30'(pipe_in_ctrl_i.mode.lsu.nfields)), 2'b0};
                     default: ;
                 endcase
             end

--- a/rtl/vproc_pending_wr.sv
+++ b/rtl/vproc_pending_wr.sv
@@ -52,6 +52,7 @@ module vproc_pending_wr #(
                 endcase
 
                 if(mode_i.lsu.stride == LSU_INDEXED) begin
+                    // for index stride the lmul for data is stored in alt
                     unique case ({mode_i.lsu.alt_emul, mode_i.lsu.nfields})
                         {EMUL_1, 3'b000}: pend_vd = 32'h01 <<  rd_i.addr              ;
                         {EMUL_1, 3'b001}: pend_vd = 32'h03 <<  rd_i.addr              ;

--- a/rtl/vproc_pending_wr.sv
+++ b/rtl/vproc_pending_wr.sv
@@ -50,6 +50,27 @@ module vproc_pending_wr #(
                     {EMUL_8, 3'b000}: pend_vd = 32'hFF << {rd_i.addr[4:3], 3'b000};
                     default: ;
                 endcase
+
+                if(mode_i.lsu.stride == LSU_INDEXED) begin
+                    unique case ({mode_i.lsu.alt_emul, mode_i.lsu.nfields})
+                        {EMUL_1, 3'b000}: pend_vd = 32'h01 <<  rd_i.addr              ;
+                        {EMUL_1, 3'b001}: pend_vd = 32'h03 <<  rd_i.addr              ;
+                        {EMUL_1, 3'b010}: pend_vd = 32'h07 <<  rd_i.addr              ;
+                        {EMUL_1, 3'b011}: pend_vd = 32'h0F <<  rd_i.addr              ;
+                        {EMUL_1, 3'b100}: pend_vd = 32'h1F <<  rd_i.addr              ;
+                        {EMUL_1, 3'b101}: pend_vd = 32'h3F <<  rd_i.addr              ;
+                        {EMUL_1, 3'b110}: pend_vd = 32'h7F <<  rd_i.addr              ;
+                        {EMUL_1, 3'b111}: pend_vd = 32'hFF <<  rd_i.addr              ;
+                        {EMUL_2, 3'b000}: pend_vd = 32'h03 << {rd_i.addr[4:1], 1'b0  };
+                        {EMUL_2, 3'b001}: pend_vd = 32'h0F << {rd_i.addr[4:1], 1'b0  };
+                        {EMUL_2, 3'b010}: pend_vd = 32'h3F << {rd_i.addr[4:1], 1'b0  };
+                        {EMUL_2, 3'b011}: pend_vd = 32'hFF << {rd_i.addr[4:1], 1'b0  };
+                        {EMUL_4, 3'b000}: pend_vd = 32'h0F << {rd_i.addr[4:2], 2'b00 };
+                        {EMUL_4, 3'b001}: pend_vd = 32'hFF << {rd_i.addr[4:2], 2'b00 };
+                        {EMUL_8, 3'b000}: pend_vd = 32'hFF << {rd_i.addr[4:3], 3'b000};
+                        default: ;
+                    endcase
+                end
             end else begin
                 unique case ({emul_i, widenarrow_i == OP_NARROWING})
                     {EMUL_1, 1'b0},

--- a/rtl/vproc_pipeline.sv
+++ b/rtl/vproc_pipeline.sv
@@ -250,7 +250,11 @@ module vproc_pipeline import vproc_pkg::*; #(
             state_next.id                      = pipe_in_state_i.id;
             state_next.unit                    = pipe_in_state_i.unit;
             state_next.mode                    = pipe_in_state_i.mode;
-            state_next.eew                     = pipe_in_state_i.eew;
+            if (pipe_in_valid_i) begin
+                state_next.eew = pipe_in_state_i.eew;
+            end else begin
+                state_next.eew = state_q.eew;
+            end
             state_next.emul                    = pipe_in_state_i.emul;
             state_next.vxrm                    = pipe_in_state_i.vxrm;
             state_next.vl                      = pipe_in_state_i.vl;

--- a/rtl/vproc_pipeline.sv
+++ b/rtl/vproc_pipeline.sv
@@ -775,6 +775,8 @@ module vproc_pipeline import vproc_pkg::*; #(
                 endcase
             end
         end
+  
+        op_fields_pend_reads |=  (state_q.field_count > 0 & state_q.mode.lsu.masked) ? 32'h1 : 32'h0;
     end
 
     logic [31:0] op_pend_reads_all;

--- a/rtl/vproc_pipeline_wrapper.sv
+++ b/rtl/vproc_pipeline_wrapper.sv
@@ -416,6 +416,9 @@ module vproc_pipeline_wrapper import vproc_pkg::*; #(
 
         if (unit_lsu) begin 
             state_init.count_inc = DONT_CARE_ZERO ? count_inc_e'('0) : count_inc_e'('x);
+            state_init.mode.lsu.alt_eew  = pipe_in_data_i.mode.lsu.eew;
+            state_init.mode.lsu.eew = pipe_in_data_i.mode.lsu.eew;
+
             unique case (pipe_in_data_i.mode.lsu.eew)
                 VSEW_8:  state_init.count_inc = COUNT_INC_1;
                 VSEW_16: state_init.count_inc = COUNT_INC_2;

--- a/rtl/vproc_pipeline_wrapper.sv
+++ b/rtl/vproc_pipeline_wrapper.sv
@@ -432,7 +432,8 @@ module vproc_pipeline_wrapper import vproc_pkg::*; #(
 
                 state_init.mode.lsu.alt_count_lsu_use = 1;
                 
-                // swap values since ei instead of e
+                // swap values since calculated eew and emul are for indexed register
+                // and the default values stored in alt are for data register
                 state_init.mode.lsu.alt_eew  = pipe_in_data_i.mode.lsu.eew;
                 state_init.mode.lsu.eew = pipe_in_data_i.mode.lsu.alt_eew;
                 state_init.eew = pipe_in_data_i.mode.lsu.alt_eew;

--- a/rtl/vproc_pkg.sv
+++ b/rtl/vproc_pkg.sv
@@ -115,22 +115,25 @@ typedef enum logic [2:0] {
 parameter int unsigned UNIT_CNT = 7;
 
 typedef enum logic [1:0] {
-    COUNT_INC_1,
-    COUNT_INC_2,
-    COUNT_INC_4,
-    COUNT_INC_MAX
+    COUNT_INC_1 = 2'b00,
+    COUNT_INC_2 = 2'b01,
+    COUNT_INC_4 = 2'b10,
+    COUNT_INC_MAX = 2'b11
 } count_inc_e;
 
 typedef enum logic [1:0] {
-    LSU_UNITSTRIDE,
-    LSU_STRIDED,
-    LSU_INDEXED
+    LSU_UNITSTRIDE = 2'b00,
+    LSU_STRIDED = 2'b01,
+    LSU_INDEXED = 2'b10
 } lsu_stride;
 
 typedef struct packed {
     logic       masked;
     logic       store;
     lsu_stride  stride;
+    logic       alt_count_lsu_use;
+    cfg_emul    alt_emul;
+    cfg_vsew    alt_eew;
     cfg_vsew    eew;
     logic [2:0] nfields;
 `ifdef VPROC_OP_MODE_UNION
@@ -192,6 +195,9 @@ typedef struct packed {
     logic           inv_op2;    // invert operand 2
     logic           sat_res;    // saturate result for narrowing operations
     logic           sigext;
+`ifdef VPROC_OP_MODE_UNION
+    logic [4:0] unused;
+`endif
 } op_mode_alu;
 
 typedef enum logic [1:0] {
@@ -209,7 +215,7 @@ typedef struct packed {
     logic       op2_signed;
     logic       op2_is_vd;
 `ifdef VPROC_OP_MODE_UNION
-    logic [5:0] unused;
+    logic [10:0] unused;
 `endif
 } op_mode_mul;
 
@@ -226,7 +232,7 @@ typedef struct packed {
     logic       masked;
     div_opcode_e    op;
 `ifdef VPROC_OP_MODE_UNION
-    logic [9:0] unused;
+    logic [14:0] unused;
 `endif
 } op_mode_div;
 
@@ -260,6 +266,7 @@ typedef struct packed {
     logic       src_1_narrow;
     logic       src_2_narrow;
 `ifdef VPROC_OP_MODE_UNION
+    logic [4:0] unused;
 `endif
 } op_mode_fpu;
 
@@ -273,7 +280,7 @@ typedef struct packed {
     opcode_sld_dir dir;    // slide direction
     logic          slide1; // slide 1 element
 `ifdef VPROC_OP_MODE_UNION
-    logic [9:0] unused;
+    logic [14:0] unused;
 `endif
 } op_mode_sld;
 
@@ -306,9 +313,9 @@ typedef struct packed {
     `endif
 `ifdef VPROC_OP_MODE_UNION
     `ifdef RISCV_ZVE32F
-        logic [4:0] unused;
+        logic [9:0] unused;
     `else 
-        logic [5:0] unused;
+        logic [10:0] unused;
     `endif
 `endif
 } op_mode_elem;
@@ -342,11 +349,14 @@ typedef struct packed {
     logic [1:0] agnostic;
     logic       vlmax;
     logic       keep_vl;
+`ifdef VPROC_OP_MODE_UNION
+    logic [4:0] unused;
+`endif
 } op_mode_cfg;
 
 `ifdef VPROC_OP_MODE_UNION
 typedef union packed {
-    logic [12:0]  unused;
+    logic [17:0]  unused;
 `else
 typedef struct packed {
 `endif

--- a/rtl/vproc_vregunpack.sv
+++ b/rtl/vproc_vregunpack.sv
@@ -388,10 +388,10 @@ module vproc_vregunpack
         for (int i = 0; i < OP_CNT; i++) begin
             op_load         [i] = stage_state[OP_STAGE[i]    ].op_load[i];
             op_load_flags   [i] = stage_state[OP_STAGE[i]    ].op_flags[i];
-            op_load_eew     [i] = stage_state[OP_STAGE[i]    ].alt_count_lsu_use && OP_ALT_COUNTER[i] ? stage_state[OP_STAGE[i]    ].alt_eew : stage_state[OP_STAGE[i]    ].eew;
+            op_load_eew     [i] = stage_state[OP_STAGE[i]    ].alt_count_lsu_use & OP_ALT_COUNTER[i] ? stage_state[OP_STAGE[i]    ].alt_eew : stage_state[OP_STAGE[i]    ].eew;
             op_buffer       [i] = stage_state[OP_STAGE[i] + 1].op_buffer[i];
             op_extract_flags[i] = stage_state[OP_STAGE[i] + 1].op_flags[i];
-            op_extract_eew  [i] = stage_state[OP_STAGE[i]    ].alt_count_lsu_use && OP_ALT_COUNTER[i] ? stage_state[OP_STAGE[i]    ].alt_eew : stage_state[OP_STAGE[i]    ].eew;
+            op_extract_eew  [i] = stage_state[OP_STAGE[i]    ].alt_count_lsu_use & OP_ALT_COUNTER[i] ? stage_state[OP_STAGE[i]    ].alt_eew : stage_state[OP_STAGE[i]    ].eew;
             op_xval         [i] = stage_state[OP_STAGE[i] + 1].op_xval[i];
         end
     end

--- a/rtl/vproc_vregunpack.sv
+++ b/rtl/vproc_vregunpack.sv
@@ -50,7 +50,6 @@ module vproc_vregunpack
         input  logic                                  pipe_in_valid_i,
         output logic                                  pipe_in_ready_o,
         input  logic               [CTRL_DATA_W-1:0]  pipe_in_ctrl_i,       // pipeline control sigs
-        input  logic                                  pipe_in_first_iter_i,
         input  logic                                  pipe_in_alt_count_lsu_use_i,
         input  vproc_pkg::cfg_vsew                    pipe_in_alt_eew_i,
         input  vproc_pkg::cfg_vsew                    pipe_in_eew_i,        // current element width
@@ -110,7 +109,6 @@ module vproc_vregunpack
         logic   [OP_CNT-1:0][31           :0] op_xval;
         logic   [OP_CNT-1:0][MAX_VPORT_W-1:0] op_buffer;
         logic   [OP_CNT-1:0][MAX_OP_W   -1:0] op_data;
-        logic   [OP_CNT-1:0]                  op_first_iter;
     } vregunpack_state_t;
 
     vregunpack_state_t stage_0;
@@ -125,7 +123,6 @@ module vproc_vregunpack
         stage_0.op_vaddr = pipe_in_op_vaddr_i;
         stage_0.op_flags = pipe_in_op_flags_i;
         stage_0.op_xval  = pipe_in_op_xval_i;
-        stage_0.op_first_iter = pipe_in_first_iter_i;
         `else
         if (pipe_in_ready_o & pipe_in_valid_i) begin
             stage_0.ctrl     = pipe_in_ctrl_i;
@@ -136,7 +133,6 @@ module vproc_vregunpack
             stage_0.op_vaddr = pipe_in_op_vaddr_i;
             stage_0.op_flags = pipe_in_op_flags_i;
             stage_0.op_xval  = pipe_in_op_xval_i;
-            stage_0.op_first_iter = pipe_in_first_iter_i;
         end
         `endif
     end
@@ -147,7 +143,6 @@ module vproc_vregunpack
     logic              [UNPACK_STAGES:0] stage_valid, stage_valid_q, stage_valid_d;
     vregunpack_state_t [UNPACK_STAGES:0] stage_state, stage_state_q, stage_state_d;
     logic              [UNPACK_STAGES:0] stage_ready;
-    logic              [OP_CNT-1:0][MAX_VPORT_W-1:0] mask_buffer_q, mask_buffer_d;
 
     always_ff @(posedge clk_i or negedge async_rst_ni) begin
         if (~async_rst_ni) begin
@@ -162,7 +157,6 @@ module vproc_vregunpack
     end
     always_ff @(posedge clk_i) begin
         stage_state_q <= stage_state_d;
-        mask_buffer_q <= mask_buffer_d;
     end
 
     always_comb begin
@@ -181,7 +175,6 @@ module vproc_vregunpack
     // Operand buffers next-state signal and extracted operand data
     logic [OP_CNT-1:0][MAX_VPORT_W-1:0] op_buffer_next;
     logic [OP_CNT-1:0][MAX_OP_W   -1:0] op_data;
-    logic [OP_CNT-1:0][MAX_VPORT_W-1:0] mask_buffer_next;
 
     always_comb begin
         stage_valid_d = stage_valid_q;
@@ -220,8 +213,6 @@ module vproc_vregunpack
                 end
             end
         end
-
-        mask_buffer_d = mask_buffer_next;
     end
 
     always_comb begin
@@ -393,9 +384,6 @@ module vproc_vregunpack
     FLAGS_T  [OP_CNT-1:0]                  op_extract_flags;
     cfg_vsew [OP_CNT-1:0]                  op_extract_eew;
     logic    [OP_CNT-1:0][31           :0] op_xval;
-    logic    [OP_CNT-1:0]                  op_first_iter;
-
-    logic    [OP_CNT-1:0][MAX_VPORT_W-1:0] mask_buffer;
     always_comb begin
         for (int i = 0; i < OP_CNT; i++) begin
             op_load         [i] = stage_state[OP_STAGE[i]    ].op_load[i];
@@ -405,9 +393,6 @@ module vproc_vregunpack
             op_extract_flags[i] = stage_state[OP_STAGE[i] + 1].op_flags[i];
             op_extract_eew  [i] = stage_state[OP_STAGE[i]    ].alt_count_lsu_use & OP_ALT_COUNTER[i] ? stage_state[OP_STAGE[i]    ].alt_eew : stage_state[OP_STAGE[i]    ].eew;
             op_xval         [i] = stage_state[OP_STAGE[i] + 1].op_xval[i];
-            op_first_iter   [i] = stage_state[OP_STAGE[i]  + 1].op_first_iter;
-
-            mask_buffer     [i] = mask_buffer_q[i];
         end
 
     end
@@ -476,10 +461,6 @@ module vproc_vregunpack
             localparam int unsigned OP_VPORT_W = (OP_SRC[i] < VPORT_CNT) ? VPORT_W[OP_SRC[i]] :
                                                                            VPORT_V0_W;
             always_comb begin
-                if (OP_MASK[i]) begin
-                    mask_buffer_next[i] = mask_buffer[i];
-                end
-
                 // by default, retain current value for upper part and assign default value for
                 // lower part
                 op_buffer_next[i] = {op_buffer[i][MAX_VPORT_W-1:OP_W[i]], op_default};
@@ -493,17 +474,6 @@ module vproc_vregunpack
                 // load signal overrides all others and moves vreg value into buffer
                 if (op_load[i]) begin
                     op_buffer_next[i][OP_VPORT_W-1:0] = op_vreg_data[i][OP_VPORT_W-1:0];
-
-                    if(OP_MASK[i]) begin
-                        if(~op_first_iter[i]) begin
-                            // segmented instruction therefore load mask from buffered mask register
-                            op_buffer_next[i][OP_VPORT_W-1:0] = mask_buffer[i][OP_VPORT_W-1:0];
-                        end else begin
-                            // store mask in case of segmented instruction
-                            mask_buffer_next[i][OP_VPORT_W-1:0] = op_vreg_data[i][OP_VPORT_W-1:0];
-                        end
-                    end
-
                 end
 
             end

--- a/rtl/vproc_vregunpack.sv
+++ b/rtl/vproc_vregunpack.sv
@@ -496,8 +496,10 @@ module vproc_vregunpack
 
                     if(OP_MASK[i]) begin
                         if(~op_first_iter[i]) begin
+                            // segmented instruction therefore load mask from buffered mask register
                             op_buffer_next[i][OP_VPORT_W-1:0] = mask_buffer[i][OP_VPORT_W-1:0];
                         end else begin
+                            // store mask in case of segmented instruction
                             mask_buffer_next[i][OP_VPORT_W-1:0] = op_vreg_data[i][OP_VPORT_W-1:0];
                         end
                     end

--- a/rtl/vproc_vregunpack.sv
+++ b/rtl/vproc_vregunpack.sv
@@ -33,7 +33,9 @@ module vproc_vregunpack
         parameter int unsigned                        UNPACK_STAGES      = 2,    // stage count
         parameter type                                FLAGS_T            = logic,// load struct type
         parameter int unsigned                        CTRL_DATA_W        = 0,    // ctrl data width
-        parameter bit                                 DONT_CARE_ZERO     = 1'b0  // set don't care 0
+        parameter bit                                 DONT_CARE_ZERO     = 1'b0,  // set don't care 0
+
+        parameter bit [OP_CNT-1:0]                    OP_ALT_COUNTER     = '0
     )(
         input  logic                                  clk_i,
         input  logic                                  async_rst_ni,
@@ -48,6 +50,8 @@ module vproc_vregunpack
         input  logic                                  pipe_in_valid_i,
         output logic                                  pipe_in_ready_o,
         input  logic               [CTRL_DATA_W-1:0]  pipe_in_ctrl_i,       // pipeline control sigs
+        input  logic                                  pipe_in_alt_lsu_use_i,
+        input  vproc_pkg::cfg_vsew                    pipe_in_alt_eew_i,
         input  vproc_pkg::cfg_vsew                    pipe_in_eew_i,        // current element width
         input  logic   [OP_CNT-1:0]                   pipe_in_op_load_i,    // load signals of ops
         input  logic   [OP_CNT-1:0][MAX_VADDR_W-1:0]  pipe_in_op_vaddr_i,   // vreg addresses of ops
@@ -96,7 +100,9 @@ module vproc_vregunpack
 
     typedef struct packed {
         logic               [CTRL_DATA_W-1:0] ctrl;
+        logic                                 alt_count_lsu_use;
         cfg_vsew                              eew;
+        cfg_vsew                              alt_eew;
         logic   [OP_CNT-1:0]                  op_load;
         logic   [OP_CNT-1:0][MAX_VADDR_W-1:0] op_vaddr;
         FLAGS_T [OP_CNT-1:0]                  op_flags;
@@ -110,6 +116,8 @@ module vproc_vregunpack
         stage_0          = vregunpack_state_t'(DONT_CARE_ZERO ? '0 : 'x);
         `ifdef OLD_VICUNA
         stage_0.ctrl     = pipe_in_ctrl_i;
+        stage_0.alt_count_lsu_use = pipe_in_alt_lsu_use_i;
+        stage_0.alt_eew  = pipe_in_alt_eew_i;
         stage_0.eew      = pipe_in_eew_i;
         stage_0.op_load  = pipe_in_op_load_i;
         stage_0.op_vaddr = pipe_in_op_vaddr_i;
@@ -118,6 +126,8 @@ module vproc_vregunpack
         `else
         if (pipe_in_ready_o & pipe_in_valid_i) begin
             stage_0.ctrl     = pipe_in_ctrl_i;
+            stage_0.alt_count_lsu_use = pipe_in_alt_lsu_use_i;
+            stage_0.alt_eew  = pipe_in_alt_eew_i;
             stage_0.eew      = pipe_in_eew_i;
             stage_0.op_load  = pipe_in_op_load_i;
             stage_0.op_vaddr = pipe_in_op_vaddr_i;
@@ -378,10 +388,10 @@ module vproc_vregunpack
         for (int i = 0; i < OP_CNT; i++) begin
             op_load         [i] = stage_state[OP_STAGE[i]    ].op_load[i];
             op_load_flags   [i] = stage_state[OP_STAGE[i]    ].op_flags[i];
-            op_load_eew     [i] = stage_state[OP_STAGE[i]    ].eew;
+            op_load_eew     [i] = stage_state[OP_STAGE[i]    ].alt_count_lsu_use && OP_ALT_COUNTER[i] ? stage_state[OP_STAGE[i]    ].alt_eew : stage_state[OP_STAGE[i]    ].eew;
             op_buffer       [i] = stage_state[OP_STAGE[i] + 1].op_buffer[i];
             op_extract_flags[i] = stage_state[OP_STAGE[i] + 1].op_flags[i];
-            op_extract_eew  [i] = stage_state[OP_STAGE[i] + 1].eew;
+            op_extract_eew  [i] = stage_state[OP_STAGE[i]    ].alt_count_lsu_use && OP_ALT_COUNTER[i] ? stage_state[OP_STAGE[i]    ].alt_eew : stage_state[OP_STAGE[i]    ].eew;
             op_xval         [i] = stage_state[OP_STAGE[i] + 1].op_xval[i];
         end
     end

--- a/sva/vproc_pipeline_sva.svh
+++ b/sva/vproc_pipeline_sva.svh
@@ -22,7 +22,7 @@
             end
             assert property (
                 @(posedge clk_i)
-                $rose(vreg_pend_rd_o[g]) |-> (state_q.first_cycle | $fell(state_q.pend_vreg_wr[g]) | state_q.mode.lsu.alt_count_lsu_use)
+                $rose(vreg_pend_rd_o[g]) |-> (state_q.first_cycle | $fell(state_q.pend_vreg_wr[g]))
             ) else begin
                 $error("pending read for vreg %d added midway", g);
             end

--- a/sva/vproc_pipeline_sva.svh
+++ b/sva/vproc_pipeline_sva.svh
@@ -22,7 +22,7 @@
             end
             assert property (
                 @(posedge clk_i)
-                $rose(vreg_pend_rd_o[g]) |-> (state_q.first_cycle | $fell(state_q.pend_vreg_wr[g]))
+                $rose(vreg_pend_rd_o[g]) |-> (state_q.first_cycle | $fell(state_q.pend_vreg_wr[g]) | state_q.mode.lsu.alt_count_lsu_use)
             ) else begin
                 $error("pending read for vreg %d added midway", g);
             end


### PR DESCRIPTION
In the current main branch load/store with indexed strides are only working if the data and index registers have the same eew. Further the mask output from the unpack unit was wrong in the last extraction since a wrong eew was used. The proposed changes fixes vlox/vlux, vsox/vsux and vle16. The chipsalliance tests still fail for all segmented load/store with indexed strides and for segmented ff instructions.