### PR TITLE
Implemented Zvbb and Zvbc extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ message(STATUS "CMake Version ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CM
 
 
 
-#Currently Supported: rv32im_zve32x, rv32imf_zve32f, rv32imf_zfh_zve32f_zvfh
+#Currently Supported: rv32im_zve32x, rv32imf_zve32f, rv32imf_zfh_zve32f_zvfh, rv32im_zve32x_zvbb, rv32im_zve32x_zvbc, rv32im_zve32x_zvbb_zvbc
 #Defaults are overwritten with user configurations defined on command line
 set(RISCV_ARCH rv32im_zve32x CACHE STRING "Specify the configuration")
 set(VREG_W 128 CACHE STRING "VREG_W")
@@ -39,19 +39,49 @@ if(${RISCV_ARCH} STREQUAL "rv32im_zve32x")
     set(RISCV_ZVE32X "-DRISCV_ZVE32X" )
     set(RISCV_ZVE32F "" )
     set(RISCV_ZVFH "" )
+    set(RISCV_ZVBB "" )
+    set(RISCV_ZVBC "" )
     set(VPROC_CONFIG dual-zve32x)
     
 elseif(${RISCV_ARCH} STREQUAL "rv32imf_zve32f")
     set(RISCV_ZVE32X "-DRISCV_ZVE32X" )
     set(RISCV_ZVE32F "-DRISCV_ZVE32F" )
     set(RISCV_ZVFH "" )
+    set(RISCV_ZVBB "" )
+    set(RISCV_ZVBC "" )
     set(VPROC_CONFIG dual-zve32f)
     
 elseif(${RISCV_ARCH} STREQUAL "rv32imf_zfh_zve32f_zvfh") #Build CV32E40X with Vicuna (+floating point + half precision float) and FPU on the Xif interface
     set(RISCV_ZVE32X "-DRISCV_ZVE32X" )
     set(RISCV_ZVE32F "-DRISCV_ZVE32F" )
     set(RISCV_ZVFH "-DRISCV_ZVFH" )
+    set(RISCV_ZVBB "" )
+    set(RISCV_ZVBC "" )
     set(VPROC_CONFIG dual-zve32f) #pipeline configuration same as Zve32f.  VICUNA_FLAGS provides configuration for half float support
+
+elseif(${RISCV_ARCH} STREQUAL "rv32im_zve32x_zvbb") # Zvbb Crypto extension included
+    set(RISCV_ZVE32X "-DRISCV_ZVE32X" )
+    set(RISCV_ZVE32F "" )
+    set(RISCV_ZVFH "" )
+    set(RISCV_ZVBB "-DRISCV_ZVBB" )
+    set(RISCV_ZVBC "" )
+    set(VPROC_CONFIG dual-zve32x)
+
+elseif(${RISCV_ARCH} STREQUAL "rv32im_zve32x_zvbc") # Zvbc Crypto extension included
+    set(RISCV_ZVE32X "-DRISCV_ZVE32X" )
+    set(RISCV_ZVE32F "" )
+    set(RISCV_ZVFH "" )
+    set(RISCV_ZVBB "" )
+    set(RISCV_ZVBC "-DRISCV_ZVBC" )
+    set(VPROC_CONFIG dual-zve32x)
+
+elseif(${RISCV_ARCH} STREQUAL "rv32im_zve32x_zvbb_zvbc") # Zvbb and Zvbc Crypto extension included
+    set(RISCV_ZVE32X "-DRISCV_ZVE32X" )
+    set(RISCV_ZVE32F "" )
+    set(RISCV_ZVFH "" )
+    set(RISCV_ZVBB "-DRISCV_ZVBB" )
+    set(RISCV_ZVBC "-DRISCV_ZVBC" )
+    set(VPROC_CONFIG dual-zve32x)
 
 else()
     #message(FATAL_ERROR "Unsupported RISCV_ARCH selected for Vicuna Co-processor") #TODO: Scalar Selections don't need to cause a fatal error
@@ -92,6 +122,8 @@ set(VICUNA_SOURCE   ${DESIGN_RTL_DIR_VICUNA}/vproc_pkg.sv                       
                     ${DESIGN_RTL_DIR_VICUNA}/vproc_lsu.sv
                     ${DESIGN_RTL_DIR_VICUNA}/vproc_mul.sv
                     ${DESIGN_RTL_DIR_VICUNA}/vproc_mul_block.sv
+                    ${DESIGN_RTL_DIR_VICUNA}/vproc_zvbb.sv
+                    ${DESIGN_RTL_DIR_VICUNA}/vproc_zvbc.sv
                     ${DESIGN_RTL_DIR_VICUNA}/vproc_pending_wr.sv
                     ${DESIGN_RTL_DIR_VICUNA}/vproc_pipeline.sv
                     ${DESIGN_RTL_DIR_VICUNA}/vproc_pipeline_wrapper.sv

--- a/config.mk
+++ b/config.mk
@@ -28,7 +28,7 @@ ifeq ($(VPROC_CONFIG), compact)
   VPORT_POLICY    ?= some
   VMEM_W          ?= 32
   VREG_W          ?= $(VREG_W)
-  VPROC_PIPELINES ?= $(VMEM_W):VLSU,VALU,VMUL,VSLD,VELEM
+  VPROC_PIPELINES ?= $(VMEM_W):VLSU,VALU,VMUL,VSLD,VELEM,VZVBB,VZVBC
 else
 ifeq ($(VPROC_CONFIG), dual)
   VPORT_POLICY    ?= some
@@ -116,7 +116,7 @@ $(VPROC_CONFIG_PKG):
 	    width=`echo $$pipe | cut -d ":" -f 1`;                                                    \
 	    unit_str=`echo $$pipe | cut -d ":" -f 2 | sed 's/,/, /g'`;                                \
 	    unit_mask=`echo $$pipe | cut -d ":" -f 2 | sed 's/,/ | /g' |                              \
-	               sed "s/V\(LSU\|ALU\|MUL\|SLD\|ELEM\|DIV\|FPU\)/(UNIT_CNT'(1) << UNIT_\1)/g"`;  \
+	               sed "s/V\(LSU\|ALU\|MUL\|SLD\|ELEM\|DIV\|FPU\|ZVBB\|ZVBC\)/(UNIT_CNT'(1) << UNIT_\1)/g"`;  \
 	    vport_cnt=1;                                                                              \
 	    if echo "$$pipe" | grep -q "VMUL" && [ $$(($$width * 4)) -gt "$(VREG_W)" ]; then          \
 	        vport_cnt=2;                                                                          \

--- a/rtl/vproc_decoder.sv
+++ b/rtl/vproc_decoder.sv
@@ -348,7 +348,24 @@ module vproc_decoder #(
                     3'b011: begin   // OPIVI
                         rs1_o.vreg    = 1'b0; // rs1 field contains immediate (sign extend for all except slide instructions)
                         rs1_o.xreg    = 1'b0;
-                        rs1_o.r.xval  = ((instr_i[31:26] == 6'b001110) | (instr_i[31:26] == 6'b001111)) ? {{27{1'b0}}, instr_vs1} : {{27{instr_vs1[4]}}, instr_vs1};
+                        unique case(instr_i[31:26])
+                            
+                            6'b001110, // Slide instructions
+                            6'b001111, // Slide instructions
+                            6'b110101 : begin // VWSLL
+                                rs1_o.r.xval = {{27{1'b0}}, instr_vs1};
+                            end
+                            // VROR immeadiate has an immediate of size 6
+                            6'b010100,
+                            6'b010101: begin
+                                rs1_o.r.xval = {{26{1'b0}}, instr_i[26], instr_vs1};
+                            end
+                            // All other instruction are sign extended
+                            default: begin
+                                rs1_o.r.xval = {{27{instr_vs1[4]}}, instr_vs1};
+                            end
+                        endcase
+                        //rs1_o.r.xval  = ((instr_i[31:26] == 6'b001110) | (instr_i[31:26] == 6'b001111)) ? {{27{1'b0}}, instr_vs1} : {{27{instr_vs1[4]}}, instr_vs1};
                         rs2_o.vreg    = 1'b1; // rs2 is a vector register
                         rs2_o.r.vaddr = instr_vs2;
                     end
@@ -737,31 +754,67 @@ module vproc_decoder #(
                             mode_o.alu.cmp      = 1'b0;
                             vxrm_o              = VXRM_RDN;
                         end
-                        {6'b010010, 3'b010}: begin  // v[z|s]ext.[vf2/vf4] VV
-                            unit_o              = UNIT_ALU;
-                            mode_o.alu.opx2.res = ALU_VSEL;
-                            mode_o.alu.opx1.sel = ALU_SEL_MASK;
-                            mode_o.alu.shift_op = 1'b0;
-                            mode_o.alu.inv_op1  = 1'b0;
-                            mode_o.alu.inv_op2  = 1'b0;
-                            mode_o.alu.sat_res  = 1'b0;
-                            mode_o.alu.op_mask  = instr_masked ? ALU_MASK_WRITE : ALU_MASK_NONE;
-                            mode_o.alu.cmp      = 1'b0;
-                            mode_o.alu.sigext   = instr_vs1[0];
-                            rs1_o.vreg          = 1'b0;
-                            unique case (instr_vs1[4:1])
-                                4'b0011 : begin
-                                    instr_illegal       = 1'b0;
-                                    widenarrow_o        = OP_WIDENING_EXT2;
+                        {6'b010010, 3'b010}: begin  // VXUNARY0
+                            rs1_o.vreg          = 1'b0; // No vector register
+                            unique case (instr_vs1[4:3])
+                                2'b00 : begin // v[z|s]ext.[vf2/vf4] VV
+                                    unit_o              = UNIT_ALU;
+                                    mode_o.alu.opx2.res = ALU_VSEL;
+                                    mode_o.alu.opx1.sel = ALU_SEL_MASK;
+                                    mode_o.alu.shift_op = 1'b0;
+                                    mode_o.alu.inv_op1  = 1'b0;
+                                    mode_o.alu.inv_op2  = 1'b0;
+                                    mode_o.alu.sat_res  = 1'b0;
+                                    mode_o.alu.op_mask  = instr_masked ? ALU_MASK_WRITE : ALU_MASK_NONE;
+                                    mode_o.alu.cmp      = 1'b0;
+                                    mode_o.alu.sigext   = instr_vs1[0];
+                                    unique case (instr_vs1[2:1])
+                                        2'b11 : begin
+                                            instr_illegal       = 1'b0;
+                                            widenarrow_o        = OP_WIDENING_EXT2;
+                                        end
+                                        2'b10 : begin
+                                            instr_illegal       = 1'b0;
+                                            widenarrow_o        = OP_WIDENING_EXT4;
+                                        end
+                                        default : begin
+                                            instr_illegal       = 1'b1;
+                                        end
+                                    endcase
+                                end 
+                                `ifdef RISCV_ZVBB
+                                2'b01 : begin
+                                    unit_o = UNIT_ZVBB;
+                                    mode_o.zvbb.masked = instr_masked;
+                                    unique case (instr_vs1[2:0])
+                                        3'b000 : begin // VBREV8
+                                            mode_o.zvbb.op = ZVBB_VBREV8;
+                                        end
+                                        3'b001 : begin // VREV8
+                                            mode_o.zvbb.op = ZVBB_VREV8;
+                                        end
+                                        3'b010 : begin // VBREV
+                                            mode_o.zvbb.op = ZVBB_VBREV;
+                                        end
+                                        3'b100 : begin // VCLZ
+                                            mode_o.zvbb.op = ZVBB_VCLZ;
+                                        end
+                                        3'b101 : begin // VCTZ
+                                            mode_o.zvbb.op = ZVBB_VCTZ;
+                                        end
+                                        3'b110 : begin // VCPOP
+                                            mode_o.zvbb.op = ZVBB_VCPOP;
+                                        end
+                                        default : begin
+                                            instr_illegal = 1'b1;
+                                        end
+                                    endcase
                                 end
-                                4'b0010 : begin
-                                    instr_illegal       = 1'b0;
-                                    widenarrow_o        = OP_WIDENING_EXT4;
-                                end
+                                `endif
                                 default : begin
-                                    instr_illegal       = 1'b1;
-                                end
-                           endcase
+                                    instr_illegal = 1'b1;
+                                end 
+                            endcase
                         end
                         {6'b011000, 3'b010}: begin  // vmandnot VV
                             emul_override       = 1'b1;
@@ -2228,6 +2281,56 @@ module vproc_decoder #(
                                 rs2_o.vreg         = ~instr_vs1[0]; // vid has no source reg
                             end
                         end
+
+                        `ifdef RISCV_ZVBB
+                        // ZVBB
+                        {6'b000001, 3'b000},
+                        {6'b000001, 3'b100} : begin // VANDN
+                            unit_o          = UNIT_ZVBB;
+                            mode_o.zvbb.op  = ZVBB_VANDN;
+                            mode_o.zvbb.masked = instr_masked;
+                        end
+                        // VBREV8, VREV8, VBREV, VCLZ, VCTL, VCPOP are VXUNARY0 and thus decoded above
+                        {6'b010101, 3'b000},
+                        {6'b010101, 3'b100} : begin // VROL
+                            unit_o          = UNIT_ZVBB;
+                            mode_o.zvbb.op  = ZVBB_VROL;
+                            mode_o.zvbb.masked = instr_masked;
+                        end
+                        {6'b010100, 3'b000},
+                        {6'b010100, 3'b100},
+                        {6'b010100, 3'b011},
+                        {6'b010101, 3'b011} : begin // VROR
+                            unit_o          = UNIT_ZVBB;
+                            mode_o.zvbb.op  = ZVBB_VROR;
+                            mode_o.zvbb.masked = instr_masked;
+                        end
+                        {6'b110101, 3'b000},
+                        {6'b110101, 3'b100},
+                        {6'b110101, 3'b011} : begin // VWSLL
+                            unit_o          = UNIT_ZVBB;
+                            mode_o.zvbb.op  = ZVBB_VWSLL;
+                            mode_o.zvbb.masked = instr_masked;
+                            widenarrow_o    = OP_WIDENING;
+                        end
+                        `endif
+
+                        `ifdef RISCV_ZVBC
+                        // ZVBC
+                        {6'b001100, 3'b010},
+                        {6'b001100, 3'b110} : begin // VCLMUL
+                            unit_o          = UNIT_ZVBC;
+                            mode_o.zvbc.op  = ZVBC_VCLMUL;
+                            mode_o.zvbc.masked = instr_masked;
+                        end
+                        {6'b001101, 3'b010},
+                        {6'b001101, 3'b110} : begin // VCLMULH
+                            unit_o          = UNIT_ZVBC;
+                            mode_o.zvbc.op  = ZVBC_VCLMULH;
+                            mode_o.zvbc.masked = instr_masked;
+                        end
+                        `endif
+                        // TODO: Add new instructions here
 
                         default: begin
                             instr_illegal = 1'b1;

--- a/rtl/vproc_pipeline_wrapper.sv
+++ b/rtl/vproc_pipeline_wrapper.sv
@@ -224,7 +224,7 @@ module vproc_pipeline_wrapper import vproc_pkg::*; #(
     } state_t;
 
     // identify the unit of the supplied instruction
-    logic unit_lsu, unit_alu, unit_mul, unit_sld, unit_elem, unit_div, unit_fpu;
+    logic unit_lsu, unit_alu, unit_mul, unit_sld, unit_elem, unit_div, unit_fpu, unit_zvbb, unit_zvbc;
     assign unit_lsu  = UNITS[UNIT_LSU ] & (pipe_in_data_i.unit == UNIT_LSU );
     assign unit_alu  = UNITS[UNIT_ALU ] & (pipe_in_data_i.unit == UNIT_ALU );
     assign unit_mul  = UNITS[UNIT_MUL ] & (pipe_in_data_i.unit == UNIT_MUL );
@@ -232,6 +232,8 @@ module vproc_pipeline_wrapper import vproc_pkg::*; #(
     assign unit_elem = UNITS[UNIT_ELEM] & (pipe_in_data_i.unit == UNIT_ELEM);
     assign unit_div  = UNITS[UNIT_DIV]  & (pipe_in_data_i.unit == UNIT_DIV);
     assign unit_fpu  = UNITS[UNIT_FPU]  & (pipe_in_data_i.unit == UNIT_FPU);
+    assign unit_zvbb  = UNITS[UNIT_ZVBB]  & (pipe_in_data_i.unit == UNIT_ZVBB);
+    assign unit_zvbc  = UNITS[UNIT_ZVBC]  & (pipe_in_data_i.unit == UNIT_ZVBC);
 
     // identify the type of data that vs2 supplies for ELEM instructions
     logic elem_flush, elem_vs2_data, elem_vs2_mask, elem_vs2_dyn_addr;
@@ -515,6 +517,9 @@ module vproc_pipeline_wrapper import vproc_pkg::*; #(
             unit_fpu:  state_init.op_flags[OP_CNT-1].vreg = pipe_in_data_i.mode.div.masked;
             unit_sld:  state_init.op_flags[OP_CNT-1].vreg = pipe_in_data_i.mode.sld.masked;
             unit_elem: state_init.op_flags[OP_CNT-1].vreg = pipe_in_data_i.mode.elem.masked;
+            unit_zvbb: state_init.op_flags[OP_CNT-1].vreg = pipe_in_data_i.mode.zvbb.masked;
+            unit_zvbc: state_init.op_flags[OP_CNT-1].vreg = pipe_in_data_i.mode.zvbc.masked;
+            unit_zvlc: state_init.op_flags[OP_CNT-1].vreg = pipe_in_data_i.mode.zvlc.masked;
             default: ;
         endcase
 

--- a/rtl/vproc_pipeline_wrapper.sv
+++ b/rtl/vproc_pipeline_wrapper.sv
@@ -519,7 +519,6 @@ module vproc_pipeline_wrapper import vproc_pkg::*; #(
             unit_elem: state_init.op_flags[OP_CNT-1].vreg = pipe_in_data_i.mode.elem.masked;
             unit_zvbb: state_init.op_flags[OP_CNT-1].vreg = pipe_in_data_i.mode.zvbb.masked;
             unit_zvbc: state_init.op_flags[OP_CNT-1].vreg = pipe_in_data_i.mode.zvbc.masked;
-            unit_zvlc: state_init.op_flags[OP_CNT-1].vreg = pipe_in_data_i.mode.zvlc.masked;
             default: ;
         endcase
 

--- a/rtl/vproc_pkg.sv
+++ b/rtl/vproc_pkg.sv
@@ -99,7 +99,7 @@ typedef enum logic [1:0] {
     VXRM_ROD = 2'b11    // round-to-odd
 } cfg_vxrm;
 
-typedef enum logic [2:0] {
+typedef enum logic [3:0] {
     UNIT_LSU,
     UNIT_ALU,
     UNIT_MUL,
@@ -107,12 +107,14 @@ typedef enum logic [2:0] {
     UNIT_FPU,
     UNIT_SLD,
     UNIT_ELEM,
+    UNIT_ZVBB,
+    UNIT_ZVBC,
     // pseudo-units (used for instructions that require no unit):
     UNIT_CFG
 } op_unit;
 
 // The number of different types of execution units (excludes pseudo-units)
-parameter int unsigned UNIT_CNT = 7;
+parameter int unsigned UNIT_CNT = 10;
 
 typedef enum logic [1:0] {
     COUNT_INC_1 = 2'b00,
@@ -354,6 +356,38 @@ typedef struct packed {
 `endif
 } op_mode_cfg;
 
+// ZVBB Structs
+
+typedef enum logic [3:0] { 
+    ZVBB_VANDN = 4'b0000,
+    ZVBB_VBREV = 4'b0001,
+    ZVBB_VBREV8 = 4'b0010,
+    ZVBB_VREV8 = 4'b0011,
+    ZVBB_VCLZ = 4'b0100,
+    ZVBB_VCTZ = 4'b0101,
+    ZVBB_VCPOP = 4'b0110,
+    ZVBB_VROL = 4'b0111,
+    ZVBB_VROR = 4'b1000,
+    ZVBB_VWSLL = 4'b1001
+} opcode_zvbb;
+
+typedef struct packed {
+    logic masked;
+    opcode_zvbb op; 
+} op_mode_zvbb;
+
+// ZVBC Structs
+
+typedef enum logic { 
+    ZVBC_VCLMUL = 1'b0,
+    ZVBC_VCLMULH = 1'b1
+} opcode_zvbc;
+
+typedef struct packed {
+    logic masked;
+    opcode_zvbc op; 
+} op_mode_zvbc;
+
 `ifdef VPROC_OP_MODE_UNION
 typedef union packed {
     logic [17:0]  unused;
@@ -368,6 +402,8 @@ typedef struct packed {
     op_mode_cfg  cfg;
     op_mode_div  div;
     op_mode_fpu  fpu;
+    op_mode_zvbb zvbb;
+    op_mode_zvbc zvbc;
 } op_mode;
 
 // source register type:

--- a/rtl/vproc_unit_wrapper.sv
+++ b/rtl/vproc_unit_wrapper.sv
@@ -742,5 +742,94 @@ module vproc_unit_wrapper import vproc_pkg::*; #(
                 end
             end
         end
+        else if (UNIT == UNIT_ZVBB) begin
+            CTRL_T                 unit_out_ctrl;
+            logic [MAX_OP_W  -1:0] unit_out_res;
+            logic [MAX_OP_W/8-1:0] unit_out_mask;
+            vproc_zvbb #(
+                .ZVBB_OP_W        ( MAX_OP_W                                    ),
+                .CTRL_T           ( CTRL_T                                      ),
+                .DONT_CARE_ZERO   ( DONT_CARE_ZERO                              )
+            ) zvbb (
+                .clk_i            ( clk_i                                       ),
+                .async_rst_ni     ( async_rst_ni                                ),
+                .sync_rst_ni      ( sync_rst_ni                                 ),
+                .pipe_in_valid_i  ( pipe_in_valid_i                             ),
+                .pipe_in_ready_o  ( pipe_in_ready_o                             ),
+                .pipe_in_ctrl_i   ( pipe_in_ctrl_i                              ),
+                .pipe_in_op1_i    ( pipe_in_op_data_i[1]                        ),
+                .pipe_in_op2_i    ( pipe_in_op_data_i[0]                        ),
+                .pipe_in_mask_i   ( pipe_in_op_data_i[OP_CNT-1][MAX_OP_W/8-1:0] ),
+                .pipe_out_valid_o ( pipe_out_valid_o                            ),
+                .pipe_out_ready_i ( pipe_out_ready_i                            ),
+                .pipe_out_ctrl_o  ( unit_out_ctrl                               ),
+                .pipe_out_res_o   ( unit_out_res                                ),
+                .pipe_out_mask_o  ( unit_out_mask                               )
+            );
+            always_comb begin
+                pipe_out_instr_id_o = unit_out_ctrl.id;
+                pipe_out_eew_o      = unit_out_ctrl.eew;
+                pipe_out_vaddr_o    = unit_out_ctrl.res_vaddr;
+                pipe_out_res_store_o = '0;
+                pipe_out_res_valid_o = '0;
+                pipe_out_res_flags_o = '{default: pack_flags'('0)};
+                pipe_out_res_data_o  = '0;
+                pipe_out_res_mask_o  = '0;
+                pipe_out_res_flags_o[0].shift           = 1'b1;
+                pipe_out_res_store_o[0]                 = unit_out_ctrl.res_store;
+                pipe_out_res_valid_o[0]                 = pipe_out_valid_o;
+                pipe_out_res_data_o [0]                 = unit_out_res;
+                pipe_out_res_mask_o [0][MAX_OP_W/8-1:0] = unit_out_mask;
+                pipe_out_res_flags_o[0].vreg_idx        = unit_out_ctrl.vreg_idx;
+            end
+            assign pipe_out_pend_clear_o     = unit_out_ctrl.res_store;
+            assign pipe_out_pend_clear_cnt_o = '0;
+            assign pipe_out_instr_done_o     = unit_out_ctrl.last_cycle;
+        end
+        else if (UNIT == UNIT_ZVBC) begin
+            CTRL_T                 unit_out_ctrl;
+            logic [MAX_OP_W  -1:0] unit_out_res;
+            logic [MAX_OP_W/8-1:0] unit_out_mask;
+            vproc_zvbc #(
+                .ZVBC_OP_W        ( MAX_OP_W                                    ),
+                .CTRL_T           ( CTRL_T                                      ),
+                .DONT_CARE_ZERO   ( DONT_CARE_ZERO                              )
+            ) zvbc (
+                .clk_i            ( clk_i                                       ),
+                .async_rst_ni     ( async_rst_ni                                ),
+                .sync_rst_ni      ( sync_rst_ni                                 ),
+                .pipe_in_valid_i  ( pipe_in_valid_i                             ),
+                .pipe_in_ready_o  ( pipe_in_ready_o                             ),
+                .pipe_in_ctrl_i   ( pipe_in_ctrl_i                              ),
+                .pipe_in_op1_i    ( pipe_in_op_data_i[1]                        ),
+                .pipe_in_op2_i    ( pipe_in_op_data_i[0]                        ),
+                .pipe_in_mask_i   ( pipe_in_op_data_i[OP_CNT-1][MAX_OP_W/8-1:0] ),
+                .pipe_out_valid_o ( pipe_out_valid_o                            ),
+                .pipe_out_ready_i ( pipe_out_ready_i                            ),
+                .pipe_out_ctrl_o  ( unit_out_ctrl                               ),
+                .pipe_out_res_o   ( unit_out_res                                ),
+                .pipe_out_mask_o  ( unit_out_mask                               )
+            );
+            always_comb begin
+                pipe_out_instr_id_o = unit_out_ctrl.id;
+                pipe_out_eew_o      = unit_out_ctrl.eew;
+                pipe_out_vaddr_o    = unit_out_ctrl.res_vaddr;
+                pipe_out_res_store_o = '0;
+                pipe_out_res_valid_o = '0;
+                pipe_out_res_flags_o = '{default: pack_flags'('0)};
+                pipe_out_res_data_o  = '0;
+                pipe_out_res_mask_o  = '0;
+                pipe_out_res_flags_o[0].shift           = 1'b1;
+                pipe_out_res_store_o[0]                 = unit_out_ctrl.res_store;
+                pipe_out_res_valid_o[0]                 = pipe_out_valid_o;
+                pipe_out_res_data_o [0]                 = unit_out_res;
+                pipe_out_res_mask_o [0][MAX_OP_W/8-1:0] = unit_out_mask;
+                pipe_out_res_flags_o[0].vreg_idx        = unit_out_ctrl.vreg_idx;
+            end
+            assign pipe_out_pend_clear_o     = unit_out_ctrl.res_store;
+            assign pipe_out_pend_clear_cnt_o = '0;
+            assign pipe_out_instr_done_o     = unit_out_ctrl.last_cycle;
+        end
+        // TODO: Add new units here to pipeline
     endgenerate
 endmodule

--- a/rtl/vproc_vregunpack.sv
+++ b/rtl/vproc_vregunpack.sv
@@ -52,7 +52,7 @@ module vproc_vregunpack
         input  logic                                  pipe_in_valid_i,
         output logic                                  pipe_in_ready_o,
         input  logic               [CTRL_DATA_W-1:0]  pipe_in_ctrl_i,       // pipeline control sigs
-        input  op_unit                                pipe_in_unit_i,
+        input  vproc_pkg::op_unit                     pipe_in_unit_i,
         input  vproc_pkg::cfg_vsew                    pipe_in_alt_eew_i,
         input  vproc_pkg::cfg_vsew                    pipe_in_eew_i,        // current element width
         input  logic   [OP_CNT-1:0]                   pipe_in_op_load_i,    // load signals of ops

--- a/rtl/vproc_zvbb.sv
+++ b/rtl/vproc_zvbb.sv
@@ -8,7 +8,7 @@ module vproc_zvbb #(
         parameter bit                   BUF_OPERANDS     = 1'b1, // insert pipeline stage after operand extraction
         parameter bit                   BUF_INTERMEDIATE = 1'b1, // insert pipeline stage for for intermediate results
         parameter bit                   BUF_RESULTS      = 1'b1, // insert pipeline stage after computing result
-        parameter type                  CTRL_T           = ctrl_t,
+        parameter type                  CTRL_T           = logic,
         parameter bit                   DONT_CARE_ZERO   = 1'b0, // initialize don't care values to zero
         parameter bit                   ZKT_ACTIVE       = 1'b0  // flag to enforce data independent runtime
     )(

--- a/rtl/vproc_zvbb.sv
+++ b/rtl/vproc_zvbb.sv
@@ -1,0 +1,573 @@
+// Copyright TU Wien
+// Licensed under the Solderpad Hardware License v2.1, see LICENSE.txt for details
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+// Author: Daniel Blattner (e12020646@student.tuwien.ac.at)
+
+module vproc_zvbb #(
+        parameter int unsigned          ZVBB_OP_W        = 64,
+        parameter bit                   BUF_OPERANDS     = 1'b1, // insert pipeline stage after operand extraction
+        parameter bit                   BUF_INTERMEDIATE = 1'b1, // insert pipeline stage for for intermediate results
+        parameter bit                   BUF_RESULTS      = 1'b1, // insert pipeline stage after computing result
+        parameter type                  CTRL_T           = ctrl_t,
+        parameter bit                   DONT_CARE_ZERO   = 1'b0, // initialize don't care values to zero
+        parameter bit                   ZKT_ACTIVE       = 1'b0  // flag to enforce data independent runtime
+    )(
+        input  logic                    clk_i,
+        input  logic                    async_rst_ni,
+        input  logic                    sync_rst_ni,
+
+        input  logic                    pipe_in_valid_i,
+        output logic                    pipe_in_ready_o,
+        input  CTRL_T                   pipe_in_ctrl_i,
+        input  logic [ZVBB_OP_W  -1:0]  pipe_in_op1_i,
+        input  logic [ZVBB_OP_W  -1:0]  pipe_in_op2_i,
+        input  logic [ZVBB_OP_W/8-1:0]  pipe_in_mask_i,
+
+        output logic                    pipe_out_valid_o,
+        input  logic                    pipe_out_ready_i,
+        output CTRL_T                   pipe_out_ctrl_o,
+        output logic [ZVBB_OP_W  -1:0]  pipe_out_res_o,
+        output logic [ZVBB_OP_W/8-1:0]  pipe_out_mask_o
+    ); /*verilator public_module*/
+
+    import vproc_pkg::*;
+
+    // Parameter asserts
+    initial begin
+        // Operand width must be a multiple of 32
+        assert ( (ZVBB_OP_W & 31) == 0 ) else begin 
+            $error("ZVBB operand width (ZVBB_OP_W) must be a multiple of 32. It is currently %d",ZVBB_OP_W);
+        end
+    end
+
+    typedef struct packed {
+        CTRL_T ctrl;
+        logic [ZVBB_OP_W  -1:0] op1;
+        logic [ZVBB_OP_W  -1:0] op2;
+        logic [ZVBB_OP_W/8-1:0] mask;
+    } zvbb_instr;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // BUFFERS
+
+    localparam PIPELINE_STAGES = 3;
+    zvbb_instr stage[PIPELINE_STAGES];
+
+    // Handshake vars
+    logic valid[PIPELINE_STAGES];
+    /* verilator lint_off UNOPTFLAT */
+    logic ready[PIPELINE_STAGES];
+    /* verilator lint_on UNOPTFLAT */
+
+    generate  
+        // Input Stage
+        if (BUF_OPERANDS) begin
+            always_ff @(posedge clk_i or negedge async_rst_ni) begin : vproc_zvbb_input_stage_valid
+                if (~async_rst_ni) begin
+                    valid[0] <= 1'b0;
+                end
+                else if (~sync_rst_ni) begin
+                    valid[0] <= 1'b0;
+                end
+                else if (ready[0]) begin
+                    valid[0] <= pipe_in_valid_i;
+                end
+            end
+            always_ff @(posedge clk_i) begin : vproc_zvbb_input_stage
+                if (ready[0] & pipe_in_valid_i) begin
+                    stage[0].ctrl <= pipe_in_ctrl_i;
+                    stage[0].op1 <= pipe_in_op1_i;
+                    stage[0].op2 <= pipe_in_op2_i;
+                    stage[0].mask <= pipe_in_mask_i;
+                end
+            end
+            assign ready[0] = ~valid[0] | ready[1];
+        end else begin
+            always_comb begin : vproc_zvbb_input_stage
+                stage[0].ctrl = pipe_in_ctrl_i;
+                stage[0].op1 = pipe_in_op1_i;
+                stage[0].op2 = pipe_in_op2_i;
+                stage[0].mask = pipe_in_mask_i;
+                valid[0] = pipe_in_valid_i;
+                ready[0] = ready[1];
+            end
+        end
+        assign pipe_in_ready_o = ready[0];
+
+        // Intermediate Stage(s)
+        genvar idx;
+        for(idx=1; idx<PIPELINE_STAGES-1; idx++) begin
+            if (BUF_INTERMEDIATE) begin
+                always_ff @(posedge clk_i or negedge async_rst_ni) begin : vproc_zvbb_intermediate_stage_valid
+                    if (~async_rst_ni) begin
+                        valid[idx] <= 1'b0;
+                    end
+                    else if (~sync_rst_ni) begin
+                        valid[idx] <= 1'b0;
+                    end
+                    else if (ready[idx]) begin
+                        valid[idx] <= valid[idx-1];
+                    end
+                end
+                always_ff @(posedge clk_i) begin : vproc_zvbb_intermediate_stage
+                    if (ready[idx] & valid[idx-1]) begin
+                        stage[idx] <= stage[idx-1];
+                    end
+                end
+                assign ready[idx] = ~valid[idx] | ready[idx+1];
+            end else begin
+                always_comb begin : vproc_zvbb_intermediate_stage
+                    stage[idx] = stage[idx-1];
+                    valid[idx] = valid[idx-1];
+                    ready[idx] = ready[idx+1];
+                end
+            end
+        end
+
+        // Output Stage
+        if (BUF_RESULTS) begin
+            always_ff @(posedge clk_i or negedge async_rst_ni) begin : vproc_zvbb_output_stage_valid
+                if (~async_rst_ni) begin
+                    pipe_out_valid_o <= 1'b0;
+                end
+                else if (~sync_rst_ni) begin
+                    pipe_out_valid_o <= 1'b0;
+                end
+                else if (ready[PIPELINE_STAGES-1]) begin
+                    pipe_out_valid_o <= valid[PIPELINE_STAGES-2];
+                end
+            end
+            always_ff @(posedge clk_i) begin : vproc_zvbb_output_stage
+                if (ready[PIPELINE_STAGES-1] & valid[PIPELINE_STAGES-2]) begin
+                    stage[PIPELINE_STAGES-1] <= stage[PIPELINE_STAGES-2];
+                    pipe_out_res_o <= result;
+                end
+            end
+            assign ready[PIPELINE_STAGES-1] = ~valid[PIPELINE_STAGES-1] | pipe_out_ready_i;
+        end else begin
+            always_comb begin : vproc_zvbb_output_stage
+                stage[PIPELINE_STAGES-1] = stage[PIPELINE_STAGES-2];
+                valid[PIPELINE_STAGES-1] = valid[PIPELINE_STAGES-2];
+                ready[PIPELINE_STAGES-1] = pipe_out_ready_i;
+            end
+            assign pipe_out_valid_o = valid[PIPELINE_STAGES-1];
+            assign pipe_out_res_o = result;
+        end
+        assign pipe_out_ctrl_o = stage[PIPELINE_STAGES-1].ctrl;
+
+        // result byte mask
+        logic [ZVBB_OP_W/8-1:0] vl_mask;
+        assign vl_mask        = ~stage[PIPELINE_STAGES-1].ctrl.vl_part_0 ? ({(ZVBB_OP_W/8){1'b1}} >> (~stage[PIPELINE_STAGES-1].ctrl.vl_part)) : '0;
+        assign pipe_out_mask_o = (stage[PIPELINE_STAGES-1].ctrl.mode.zvbb.masked ? stage[PIPELINE_STAGES-1].mask : {(ZVBB_OP_W/8){1'b1}}) & vl_mask;
+
+    endgenerate
+
+    // BUFFERS END
+    ///////////////////////////////////////////////////////////////////////////
+
+    // Notes:
+    // -) Scalar registers or immediates are already in the operand correctly coppied
+
+    ///////////////////////////////////////////////////////////////////////////
+    // VECTOR AND-NOT
+    logic [ZVBB_OP_W-1:0] result_vandn = ~stage[PIPELINE_STAGES-2].op1 & stage[PIPELINE_STAGES-2].op2;
+    // END VECTOR AND-NOT
+    ///////////////////////////////////////////////////////////////////////////
+
+    ///////////////////////////////////////////////////////////////////////////
+    // VECTOR REVERSE
+
+    // A seperate function, which reverese the bits in bytes.
+    // It is used in several reverse instruction, especially with EEW=8
+    function logic[ZVBB_OP_W-1:0] reverseBitsInBytes;
+        input logic[ZVBB_OP_W-1:0] in;
+        logic[ZVBB_OP_W-1:0] reverseInput;
+        for(int i=0; i < ZVBB_OP_W/8; i++) begin
+            for(int j=0; j < 8; j++) begin
+                reverseInput[8*i + j] = in[8*i + 7-j];
+            end 
+        end
+        return reverseInput;
+    endfunction
+    logic [ZVBB_OP_W-1:0] reversedBitsInBytes;
+    assign reversedBitsInBytes = reverseBitsInBytes(stage[PIPELINE_STAGES-2].op2);
+
+    logic [ZVBB_OP_W-1:0] result_rev;
+    always_comb begin : chooseRevereseResult
+        result_rev = DONT_CARE_ZERO ? '0 : 'x;
+        unique case (stage[PIPELINE_STAGES-2].ctrl.mode.zvbb.op)
+            ZVBB_VBREV: begin
+                unique case (stage[PIPELINE_STAGES-2].ctrl.eew)
+                    VSEW_8: begin
+                        // Resuse the reverseBitsInByte function
+                        result_rev = reversedBitsInBytes;
+                    end
+                    VSEW_16: begin
+                        for (int i=0; i < ZVBB_OP_W/16; i++) begin
+                            for (int j=0; j < 16; j++) begin
+                                result_rev[16*i + j] = stage[PIPELINE_STAGES-2].op2[16*i + 15-j];
+                            end
+                        end
+                    end
+                    VSEW_32: begin
+                        for (int i=0; i < ZVBB_OP_W/32; i++) begin
+                            for (int j=0; j < 32; j++) begin
+                                result_rev[32*i + j] = stage[PIPELINE_STAGES-2].op2[32*i + 31-j];
+                            end
+                        end
+                    end 
+                    default: ;
+                endcase
+            end
+            ZVBB_VBREV8: begin
+                // Reverse bits in bytes is functional the same for all EEW 
+                result_rev = reversedBitsInBytes;
+            end
+            ZVBB_VREV8: begin
+                unique case (stage[PIPELINE_STAGES-2].ctrl.eew)
+                    VSEW_8: begin
+                        // Reverse bytes with EEW=8 has no effect
+                        result_rev = stage[PIPELINE_STAGES-2].op2;
+                    end
+                    VSEW_16: begin
+                        for (int i=0; i < ZVBB_OP_W/16; i++) begin
+                            result_rev[16*i +: 8] = stage[PIPELINE_STAGES-2].op2[16*i+8 +: 8];
+                            result_rev[16*i+8 +: 8] = stage[PIPELINE_STAGES-2].op2[16*i +: 8];
+                        end
+                    end
+                    VSEW_32: begin
+                        for (int i=0; i < ZVBB_OP_W/32; i++) begin
+                            result_rev[32*i +: 8] = stage[PIPELINE_STAGES-2].op2[32*i+24 +: 8];
+                            result_rev[32*i+8 +: 8] = stage[PIPELINE_STAGES-2].op2[32*i+16 +: 8];
+                            result_rev[32*i+16 +: 8] = stage[PIPELINE_STAGES-2].op2[32*i+8 +: 8];
+                            result_rev[32*i+24 +: 8] = stage[PIPELINE_STAGES-2].op2[32*i +: 8];
+                        end
+                    end 
+                    default: ;
+                endcase
+            end
+            default: ;
+        endcase
+    end
+    // END VECTOR REVERSE
+    ///////////////////////////////////////////////////////////////////////////
+
+    ///////////////////////////////////////////////////////////////////////////
+    // VECTOR COUNT ZEROS
+
+    // Credit for counting leading zeros using a balance tree structures goes to Grabul
+    // Link: https://electronics.stackexchange.com/a/196992
+    // The algorithm was sligthly modified to be usable for also counting trailing zeros
+
+    // The counting direction is given by the countDir input: 0 -> leading zeros, 1 -> trailing zeros
+    function logic[1:0] twoPair;
+        input logic [1:0] v;
+        input logic countDir;
+        // Count the leading/trailing zero of two bits
+        unique case ({countDir,v})
+            3'b000 : return 2'b10;
+            3'b001 : return 2'b01;
+            3'b110 : return 2'b01;
+            3'b100 : return 2'b10;
+            default : return 2'b00;
+        endcase
+    endfunction : twoPair
+
+    // If the first half is not max count (i.e. there is somewhere a 1), only consider the result of first half
+    // If both halfs have max count (10...0), return the max value (100...0)
+    // If the first half has max count and the second half is not max, then result if 01<secondHalf[MSB-1:0]>
+    `define combinePairs(funcName, WIDTH)                                   \
+    function logic[WIDTH:0] funcName;                                       \
+        input logic [2*WIDTH-1:0] v;                                        \
+        input logic countDir;                                               \
+        logic[WIDTH-1:0] firstHalf;                                         \
+        logic[WIDTH-1:0] secondHalf;                                        \
+        assign firstHalf = countDir ? v[0 +: WIDTH] : v[WIDTH +: WIDTH];    \
+        assign secondHalf = countDir ? v[WIDTH +: WIDTH] : v[0 +: WIDTH];   \
+        if (firstHalf[WIDTH-1] == 1'b0) begin                               \
+            return {1'b0,firstHalf};                                        \
+        end else begin                                                      \
+            return {firstHalf[WIDTH-1] & secondHalf[WIDTH-1],               \
+                    ~secondHalf[WIDTH-1],                                   \
+                    secondHalf[0 +: WIDTH-1]};                              \
+        end                                                                 \
+    endfunction : funcName;
+    `combinePairs(combineTwoWidthPairs,2);
+    `combinePairs(combineThreeWidthPairs,3);
+    `combinePairs(combineFourWidthPairs,4);
+    `combinePairs(combineFiveWidthPairs,5);
+
+    logic [(ZVBB_OP_W/2)*2-1:0] twoBitCount;
+    logic [(ZVBB_OP_W/4)*3-1:0] fourBitCount;
+    logic [(ZVBB_OP_W/8)*4-1:0] eigthBitCount;
+    logic [(ZVBB_OP_W/16)*5-1:0] sixteenBitCount;
+    logic [(ZVBB_OP_W/32)*6-1:0] thirtytwoBitCount;
+    logic countingDirection = (stage[PIPELINE_STAGES-2].ctrl.mode.zvbb.op == ZVBB_VCTZ);
+    always_comb begin : countingZeroBalancedTree
+        for (int i=0; i < ZVBB_OP_W/2; i++) begin
+            twoBitCount[2*i +: 2] = twoPair(stage[PIPELINE_STAGES-2].op2[2*i +: 2],countingDirection);
+        end
+        for(int i=0; i < ZVBB_OP_W/4; i++) begin
+            fourBitCount[3*i +: 3] = combineTwoWidthPairs(twoBitCount[4*i +: 4],countingDirection);
+        end
+        for(int i=0; i < ZVBB_OP_W/8; i++) begin
+            eigthBitCount[4*i +: 4] = combineThreeWidthPairs(fourBitCount[6*i +: 6],countingDirection);
+        end
+        for(int i=0; i < ZVBB_OP_W/16; i++) begin
+            sixteenBitCount[5*i +: 5] = combineFourWidthPairs(eigthBitCount[8*i +: 8],countingDirection);
+        end
+        for(int i=0; i < ZVBB_OP_W/32; i++) begin
+            thirtytwoBitCount[6*i +: 6] = combineFiveWidthPairs(sixteenBitCount[10*i +: 10],countingDirection);
+        end
+    end
+
+    logic [ZVBB_OP_W-1:0] result_cz;
+    always_comb begin  : chooseCountingZeroResult
+        result_cz = DONT_CARE_ZERO ? '0 : 'x;
+        unique case (stage[PIPELINE_STAGES-2].ctrl.eew)
+            VSEW_8: begin
+                for (int i=0; i < ZVBB_OP_W/8; i++) begin
+                    result_cz[8*i +: 8] = {4'b0,eigthBitCount[4*i +: 4]};
+                end
+            end
+            VSEW_16: begin
+                for (int i=0; i < ZVBB_OP_W/16; i++) begin
+                    result_cz[16*i +: 16] = {11'b0,sixteenBitCount[5*i +: 5]};
+                end
+            end
+            VSEW_32: begin
+                for (int i=0; i < ZVBB_OP_W/32; i++) begin
+                    result_cz[32*i +: 32] = {26'b0,thirtytwoBitCount[6*i +: 6]};
+                end
+            end 
+            default: ;
+        endcase
+    end
+    // END VECTOR COUNT ZEROS
+    ///////////////////////////////////////////////////////////////////////////
+
+    ///////////////////////////////////////////////////////////////////////////
+    // VECTOR POPULATION COUNT
+
+    // Masking constants
+    localparam logic [ZVBB_OP_W-1:0] twoSumPattern = {ZVBB_OP_W/2{2'b01}};
+    localparam logic [ZVBB_OP_W-1:0] fourSumPattern = {ZVBB_OP_W/4{4'h3}};
+    localparam logic [ZVBB_OP_W-1:0] eigthSumPattern = {ZVBB_OP_W/8{8'h07}};
+    // Og value 16'h001F
+    localparam logic [ZVBB_OP_W-1:0] sixteenSumPattern = {ZVBB_OP_W/16{16'h000F}};
+    // Og value 16'h003F
+    localparam logic [ZVBB_OP_W-1:0] thirtytwoSumPattern = {ZVBB_OP_W/32{32'h0000_001F}};
+    // Calculate the subtotals by shifting-mask-add operations
+    logic [ZVBB_OP_W-1:0] twoSum;
+    logic [ZVBB_OP_W-1:0] fourSum;
+    logic [ZVBB_OP_W-1:0] eigthSum;
+    logic [ZVBB_OP_W-1:0] sixteenSum;
+    logic [ZVBB_OP_W-1:0] thirtytwoSum;
+    always_comb begin : subtotalCalculation
+        twoSum = (stage[PIPELINE_STAGES-2].op2 & twoSumPattern) + 
+            ({1'b0,stage[PIPELINE_STAGES-2].op2[ZVBB_OP_W-1:1]} & twoSumPattern);
+        fourSum = (twoSum & fourSumPattern) + 
+            ({2'b0,twoSum[ZVBB_OP_W-1:2]} & fourSumPattern);
+        eigthSum = (fourSum & eigthSumPattern) + 
+            ({4'b0,fourSum[ZVBB_OP_W-1:4]} & eigthSumPattern);
+        sixteenSum = (eigthSum & sixteenSumPattern) + 
+            ({8'b0,eigthSum[ZVBB_OP_W-1:8]} & sixteenSumPattern);
+        thirtytwoSum = (sixteenSum & thirtytwoSumPattern) + 
+            ({16'b0,sixteenSum[ZVBB_OP_W-1:16]} & thirtytwoSumPattern);
+    end
+
+    logic [ZVBB_OP_W-1:0] result_vcpop;
+    always_comb begin : choosePopulationCountResult
+        result_vcpop = DONT_CARE_ZERO ? '0 : 'x;
+        unique case (stage[PIPELINE_STAGES-2].ctrl.eew)
+            VSEW_8: begin
+                result_vcpop = eigthSum;
+            end
+            VSEW_16: begin
+                result_vcpop = sixteenSum;
+            end
+            VSEW_32: begin
+                result_vcpop = thirtytwoSum;
+            end 
+            default: ;
+        endcase
+    end
+    // END VECTOR POPULATION COUNT
+    ///////////////////////////////////////////////////////////////////////////
+
+    ///////////////////////////////////////////////////////////////////////////
+    // VECTOR ROTATE
+
+    // Direction: 1 -> Left, 0 -> Right
+    // Barrel shifter for 8,16 and 32 bits
+    function logic[7:0] eigthBitRotater;
+        input logic[7:0] in;
+        input logic[2:0] bits;
+        input logic direction;
+        logic[7:0] levels[2:0];
+        if (bits[0]==1'b1) begin
+            levels[0] = direction ? {in[6:0],in[7]} : {in[0],in[7:1]};
+        end else begin
+            levels[0] = in;
+        end
+        if (bits[1]==1'b1) begin
+            levels[1] = direction ? {levels[0][5:0],levels[0][7:6]} : {levels[0][1:0],levels[0][7:2]};
+        end else begin
+            levels[1] = levels[0];
+        end
+        if (bits[2]==1'b1) begin
+            levels[2] = direction ? {levels[1][3:0],levels[1][7:4]} : {levels[1][3:0],levels[1][7:4]};
+        end else begin
+            levels[2] = levels[1];
+        end
+        return levels[2];
+    endfunction
+    function logic[15:0] sixteenBitRotater;
+        input logic[15:0] in;
+        input logic[3:0] bits;
+        input logic direction;
+        logic[15:0] levels[3:0];
+        if (bits[0]==1'b1) begin
+            levels[0] = direction ? {in[14:0],in[15]} : {in[0],in[15:1]};
+        end else begin
+            levels[0] = in;
+        end
+        if (bits[1]==1'b1) begin
+            levels[1] = direction ? {levels[0][13:0],levels[0][15:14]} : {levels[0][1:0],levels[0][15:2]};
+        end else begin
+            levels[1] = levels[0];
+        end
+        if (bits[2]==1'b1) begin
+            levels[2] = direction ? {levels[1][11:0],levels[1][15:12]} : {levels[1][3:0],levels[1][15:4]};
+        end else begin
+            levels[2] = levels[1];
+        end
+        if (bits[3]==1'b1) begin
+            levels[3] = direction ? {levels[2][7:0],levels[2][15:8]} : {levels[2][7:0],levels[2][15:8]};
+        end else begin
+            levels[3] = levels[2];
+        end
+        return levels[3];
+    endfunction
+    function logic[31:0] thirtytwoBitRotater;
+        input logic[31:0] in;
+        input logic[4:0] bits;
+        input logic direction;
+        logic[31:0] levels[4:0];
+        if (bits[0]==1'b1) begin
+            levels[0] = direction ? {in[30:0],in[31]} : {in[0],in[31:1]};
+        end else begin
+            levels[0] = in;
+        end
+        if (bits[1]==1'b1) begin
+            levels[1] = direction ? {levels[0][29:0],levels[0][31:30]} : {levels[0][1:0],levels[0][31:2]};
+        end else begin
+            levels[1] = levels[0];
+        end
+        if (bits[2]==1'b1) begin
+            levels[2] = direction ? {levels[1][27:0],levels[1][31:28]} : {levels[1][3:0],levels[1][31:4]};
+        end else begin
+            levels[2] = levels[1];
+        end
+        if (bits[3]==1'b1) begin
+            levels[3] = direction ? {levels[2][23:0],levels[2][31:24]} : {levels[2][7:0],levels[2][31:8]};
+        end else begin
+            levels[3] = levels[2];
+        end
+        if (bits[4]==1'b1) begin
+            levels[4] = direction ? {levels[3][15:0],levels[3][31:16]} : {levels[3][15:0],levels[3][31:16]};
+        end else begin
+            levels[4] = levels[3];
+        end
+        return levels[4];
+    endfunction
+
+    logic [ZVBB_OP_W  -1:0] result_rot;
+    logic rotatingDirection = (stage[PIPELINE_STAGES-2].ctrl.mode.zvbb.op == ZVBB_VROL);
+    always_comb begin : chooseRotateResult
+        result_rot = DONT_CARE_ZERO ? '0 : 'x;
+        unique case (stage[PIPELINE_STAGES-2].ctrl.eew)
+            VSEW_8: begin
+                for (int i=0; i < ZVBB_OP_W/8; i++) begin
+                    result_rot[8*i +: 8] = eigthBitRotater(
+                        stage[PIPELINE_STAGES-2].op2[8*i +: 8],
+                        stage[PIPELINE_STAGES-2].op1[8*i +: 3],
+                        rotatingDirection);
+                end
+            end
+            VSEW_16: begin
+                for (int i=0; i < ZVBB_OP_W/16; i++) begin
+                    result_rot[16*i +: 16] = sixteenBitRotater(
+                        stage[PIPELINE_STAGES-2].op2[16*i +: 16],
+                        stage[PIPELINE_STAGES-2].op1[16*i +: 4],
+                        rotatingDirection);
+                end
+            end
+            VSEW_32: begin
+                for (int i=0; i < ZVBB_OP_W/32; i++) begin
+                    result_rot[32*i +: 32] = thirtytwoBitRotater(
+                        stage[PIPELINE_STAGES-2].op2[32*i +: 32],
+                        stage[PIPELINE_STAGES-2].op1[32*i +: 5],
+                        rotatingDirection);
+                end
+            end 
+            default: ;
+        endcase
+    end
+
+    // END VECTOR ROTATE
+    ///////////////////////////////////////////////////////////////////////////
+
+    ///////////////////////////////////////////////////////////////////////////
+    // VECTOR WIDENING SHIFT LEFT
+    logic [ZVBB_OP_W-1:0] result_vwsll;
+    always_comb begin : chooseWideningShiftLeftResult
+        result_vwsll = DONT_CARE_ZERO ? '0 : 'x;
+        unique case (stage[PIPELINE_STAGES-2].ctrl.eew)
+            VSEW_8: ; // No SEW=8 should happen
+            VSEW_16: begin
+                for (int i=0; i < ZVBB_OP_W/16; i++) begin
+                    result_vwsll[16*i +: 16] = {8'b0,stage[PIPELINE_STAGES-2].op2[16*i +: 8]} << stage[PIPELINE_STAGES-2].op1[16*i +: 4];
+                end
+            end
+            VSEW_32: begin
+                for (int i=0; i < ZVBB_OP_W/32; i++) begin
+                    result_vwsll[32*i +: 32] = {16'b0,stage[PIPELINE_STAGES-2].op2[32*i +: 16]} << stage[PIPELINE_STAGES-2].op1[32*i +: 5];
+                end
+            end 
+            default: ;
+        endcase
+    end
+    // END VECTOR WIDENING SHIFT LEFT
+    ///////////////////////////////////////////////////////////////////////////
+
+    ///////////////////////////////////////////////////////////////////////////
+    // RESULT
+    logic [ZVBB_OP_W-1:0] result;
+    always_comb begin
+        result = DONT_CARE_ZERO ? '0 : 'x;
+        unique case (stage[PIPELINE_STAGES-2].ctrl.mode.zvbb.op)
+            // Vector and-not
+            ZVBB_VANDN: result = result_vandn;
+            // Vector Reverse bits/bytes
+            ZVBB_VBREV,
+            ZVBB_VBREV8,
+            ZVBB_VREV8: result = result_rev;
+            // Vector count zero
+            ZVBB_VCLZ,
+            ZVBB_VCTZ: result = result_cz;
+            // Vector population count
+            ZVBB_VCPOP: result = result_vcpop;
+            // Vector rotate
+            ZVBB_VROL,
+            ZVBB_VROR: result = result_rot;
+            // Vector widening shift left
+            ZVBB_VWSLL: result = result_vwsll;
+            default: ;
+        endcase
+    end
+    // RESULT END
+    ///////////////////////////////////////////////////////////////////////////
+
+
+endmodule

--- a/rtl/vproc_zvbc.sv
+++ b/rtl/vproc_zvbc.sv
@@ -8,7 +8,7 @@ module vproc_zvbc #(
         parameter bit                   BUF_OPERANDS     = 1'b1, // insert pipeline stage after operand extraction
         parameter bit                   BUF_INTERMEDIATE = 1'b1, // insert pipeline stage for for intermediate results
         parameter bit                   BUF_RESULTS      = 1'b1, // insert pipeline stage after computing result
-        parameter type                  CTRL_T           = ctrl_t,
+        parameter type                  CTRL_T           = logic,
         parameter bit                   DONT_CARE_ZERO   = 1'b0, // initialize don't care values to zero
         parameter bit                   ZKT_ACTIVE       = 1'b0  // flag to enforce data independent runtime
     )(
@@ -39,7 +39,7 @@ module vproc_zvbc #(
             $error("ZVBC operand width (ZVBC_OP_W) must be a multiple of 32. It is currently %d",ZVBC_OP_W);
         end
     end
-    
+
     typedef struct packed {
         CTRL_T ctrl;
         logic [ZVBC_OP_W  -1:0] op1;

--- a/rtl/vproc_zvbc.sv
+++ b/rtl/vproc_zvbc.sv
@@ -1,0 +1,284 @@
+// Copyright TU Wien
+// Licensed under the Solderpad Hardware License v2.1, see LICENSE.txt for details
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+// Author: Daniel Blattner (e12020646@student.tuwien.ac.at)
+
+module vproc_zvbc #(
+        parameter int unsigned          ZVBC_OP_W        = 64,
+        parameter bit                   BUF_OPERANDS     = 1'b1, // insert pipeline stage after operand extraction
+        parameter bit                   BUF_INTERMEDIATE = 1'b1, // insert pipeline stage for for intermediate results
+        parameter bit                   BUF_RESULTS      = 1'b1, // insert pipeline stage after computing result
+        parameter type                  CTRL_T           = ctrl_t,
+        parameter bit                   DONT_CARE_ZERO   = 1'b0, // initialize don't care values to zero
+        parameter bit                   ZKT_ACTIVE       = 1'b0  // flag to enforce data independent runtime
+    )(
+        input  logic                    clk_i,
+        input  logic                    async_rst_ni,
+        input  logic                    sync_rst_ni,
+
+        input  logic                    pipe_in_valid_i,
+        output logic                    pipe_in_ready_o,
+        input  CTRL_T                   pipe_in_ctrl_i,
+        input  logic [ZVBC_OP_W  -1:0]  pipe_in_op1_i,
+        input  logic [ZVBC_OP_W  -1:0]  pipe_in_op2_i,
+        input  logic [ZVBC_OP_W/8-1:0]  pipe_in_mask_i,
+
+        output logic                    pipe_out_valid_o,
+        input  logic                    pipe_out_ready_i,
+        output CTRL_T                   pipe_out_ctrl_o,
+        output logic [ZVBC_OP_W  -1:0]  pipe_out_res_o,
+        output logic [ZVBC_OP_W/8-1:0]  pipe_out_mask_o
+    );
+
+    import vproc_pkg::*;
+
+    // Parameter asserts
+    initial begin
+        // Operand width must be a multiple of 32
+        assert ( (ZVBC_OP_W & 31) == 0 ) else begin 
+            $error("ZVBC operand width (ZVBC_OP_W) must be a multiple of 32. It is currently %d",ZVBC_OP_W);
+        end
+    end
+    
+    typedef struct packed {
+        CTRL_T ctrl;
+        logic [ZVBC_OP_W  -1:0] op1;
+        logic [ZVBC_OP_W  -1:0] op2;
+        logic [ZVBC_OP_W/8-1:0] mask;
+    } zvbc_instr;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // BUFFERS
+
+    localparam PIPELINE_STAGES = 3;
+    zvbc_instr stage[PIPELINE_STAGES];
+
+    // Handshake vars
+    logic valid[PIPELINE_STAGES];
+    /* verilator lint_off UNOPTFLAT */
+    logic ready[PIPELINE_STAGES];
+    /* verilator lint_on UNOPTFLAT */
+
+    generate  
+        // Input Stage
+        if (BUF_OPERANDS) begin 
+            always_ff @(posedge clk_i or negedge async_rst_ni) begin : vproc_zvbc_input_stage_valid
+                if (~async_rst_ni) begin
+                    valid[0] <= 1'b0;
+                end
+                else if (~sync_rst_ni) begin
+                    valid[0] <= 1'b0;
+                end
+                else if (ready[0]) begin
+                    valid[0] <= pipe_in_valid_i;
+                end
+            end
+            always_ff @(posedge clk_i) begin : vproc_zvbc_input_stage
+                if (ready[0] & pipe_in_valid_i) begin
+                    stage[0].ctrl <= pipe_in_ctrl_i;
+                    stage[0].op1 <= pipe_in_op1_i;
+                    stage[0].op2 <= pipe_in_op2_i;
+                    stage[0].mask <= pipe_in_mask_i;
+                end
+            end
+            assign ready[0] = ~valid[0] | ready[1];
+        end else begin
+            always_comb begin : vproc_zvbc_input_stage
+                stage[0].ctrl = pipe_in_ctrl_i;
+                stage[0].op1 = pipe_in_op1_i;
+                stage[0].op2 = pipe_in_op2_i;
+                stage[0].mask = pipe_in_mask_i;
+                valid[0] = pipe_in_valid_i;
+                ready[0] = ready[1];
+            end
+        end
+        assign pipe_in_ready_o = ready[0];
+
+        // Intermediate Stage(s)
+        genvar idx;
+        for(idx=1; idx<PIPELINE_STAGES-1; idx++) begin
+            if (BUF_INTERMEDIATE) begin
+                always_ff @(posedge clk_i or negedge async_rst_ni) begin : vproc_zvbc_intermediate_stage_valid
+                    if (~async_rst_ni) begin
+                        valid[idx] <= 1'b0;
+                    end
+                    else if (~sync_rst_ni) begin
+                        valid[idx] <= 1'b0;
+                    end
+                    else if (ready[idx]) begin
+                        valid[idx] <= valid[idx-1];
+                    end
+                end
+                always_ff @(posedge clk_i) begin : vproc_zvbc_intermediate_stage
+                    if (ready[idx] & valid[idx-1]) begin
+                        stage[idx] <= stage[idx-1];
+                    end
+                end
+                assign ready[idx] = ~valid[idx] | ready[idx+1];
+            end else begin
+                always_comb begin : vproc_zvbc_intermediate_stage
+                    stage[idx] = stage[idx-1];
+                    valid[idx] = valid[idx-1];
+                    ready[idx] = ready[idx+1];
+                end
+            end
+        end
+
+        // Output Stage
+        if (BUF_RESULTS) begin
+            always_ff @(posedge clk_i or negedge async_rst_ni) begin : vproc_zvbc_output_stage_valid
+                if (~async_rst_ni) begin
+                    pipe_out_valid_o <= 1'b0;
+                end
+                else if (~sync_rst_ni) begin
+                    pipe_out_valid_o <= 1'b0;
+                end
+                else if (ready[PIPELINE_STAGES-1]) begin
+                    pipe_out_valid_o <= valid[PIPELINE_STAGES-2];
+                end
+            end
+            always_ff @(posedge clk_i) begin : vproc_zvbc_output_stage
+                if (ready[PIPELINE_STAGES-1] & valid[PIPELINE_STAGES-2]) begin
+                    stage[PIPELINE_STAGES-1] <= stage[PIPELINE_STAGES-2];
+                    pipe_out_res_o <= result;
+                end
+            end
+            assign ready[PIPELINE_STAGES-1] = ~valid[PIPELINE_STAGES-1] | pipe_out_ready_i;
+        end else begin
+            always_comb begin : vproc_zvbc_output_stage
+                stage[PIPELINE_STAGES-1] = stage[PIPELINE_STAGES-2];
+                valid[PIPELINE_STAGES-1] = valid[PIPELINE_STAGES-2];
+                ready[PIPELINE_STAGES-1] = pipe_out_ready_i;
+            end
+            assign pipe_out_valid_o = valid[PIPELINE_STAGES-1];
+            assign pipe_out_res_o = result;
+        end
+        assign pipe_out_ctrl_o = stage[PIPELINE_STAGES-1].ctrl;
+
+        // result byte mask
+        logic [ZVBC_OP_W/8-1:0] vl_mask;
+        assign vl_mask        = ~stage[PIPELINE_STAGES-1].ctrl.vl_part_0 ? ({(ZVBC_OP_W/8){1'b1}} >> (~stage[PIPELINE_STAGES-1].ctrl.vl_part)) : '0;
+        assign pipe_out_mask_o = (stage[PIPELINE_STAGES-1].ctrl.mode.zvbc.masked ? stage[PIPELINE_STAGES-1].mask : {(ZVBC_OP_W/8){1'b1}}) & vl_mask;
+
+    endgenerate
+
+    // BUFFERS END
+    ///////////////////////////////////////////////////////////////////////////
+
+    // Generate all the lane masks
+    // SEW=8 Masks
+    const logic[ZVBC_OP_W-1:0][ZVBC_OP_W-1:0] eigthBitMask = (ZVBC_OP_W*ZVBC_OP_W)'( // Truncate leading zeros
+        {ZVBC_OP_W/8{ // Repeat until the whole operand with is filled
+            {8{1'b0}}, // Create offset to "shift" base pattern
+            {8{{ZVBC_OP_W-8{1'b0}},8'hFF}} // Base pattern
+        }}
+    );
+    // SEW=16 Masks
+    const logic[ZVBC_OP_W-1:0][ZVBC_OP_W-1:0] sixteenBitMask = (ZVBC_OP_W*ZVBC_OP_W)'( // Truncate leading zeros
+        {ZVBC_OP_W/16{ // Repeat until the whole operand with is filled
+            {16{1'b0}}, // Create offset to "shift" base pattern
+            {16{{ZVBC_OP_W-16{1'b0}},16'hFFFF}} // Base pattern
+            }
+        }
+    );
+    // SEW=32 Masks
+    const logic[ZVBC_OP_W-1:0][ZVBC_OP_W-1:0] thirtytwoBitMask = (ZVBC_OP_W*ZVBC_OP_W)'( // Truncate leading zeros
+        {ZVBC_OP_W/32{ // Repeat until the whole operand with is filled
+            {32{1'b0}}, // Create offset to "shift" base pattern
+            {32{{ZVBC_OP_W-32{1'b0}},32'hFFFF_FFFF}} // Base pattern
+            }
+        }
+    );
+    
+    // Choose lane mask set accoring to SEW
+    logic[ZVBC_OP_W-1:0][ZVBC_OP_W-1:0] laneMask;
+    always_comb begin : chooseCorrectLaneMask
+        unique case (stage[PIPELINE_STAGES-2].ctrl.eew)
+            VSEW_8: begin
+                laneMask = eigthBitMask;
+            end
+            VSEW_16: begin
+                laneMask = sixteenBitMask;
+            end
+            VSEW_32: begin
+                laneMask = thirtytwoBitMask;
+            end 
+            default: ;
+        endcase
+    end
+
+    // Calculate the carryless multiplication
+    logic[ZVBC_OP_W-1:0][ZVBC_OP_W-1:0] singleMaskedLane;
+    always_comb begin : singleMaskedLaneGen
+        // First calculate each line seperatelly and mask according SEW
+        for(int i=0; i<ZVBC_OP_W; i++) begin
+            singleMaskedLane[i] = stage[PIPELINE_STAGES-2].op1 & 
+                {ZVBC_OP_W{stage[PIPELINE_STAGES-2].op2[i]}} & 
+                laneMask[i];
+        end
+    end
+    logic [ZVBC_OP_W-1:0][2*ZVBC_OP_W-1:0] paritalMul;
+    logic [2*ZVBC_OP_W-1:0] cmul;
+    always_comb begin : carrylessMultiplication
+        // XOR and shift all lanes
+        paritalMul[0] = {{ZVBC_OP_W{1'b0}},singleMaskedLane[0]};
+        /* verilator lint_off ALWCOMBORDER */
+        for(int i=1; i<ZVBC_OP_W; i++) begin
+            paritalMul[i] = paritalMul[i-1] ^ ({{ZVBC_OP_W{1'b0}},singleMaskedLane[i]} << i);
+        end
+        /* verilator lint_on ALWCOMBORDER */
+        cmul = paritalMul[ZVBC_OP_W-1];
+    end
+
+    ///////////////////////////////////////////////////////////////////////////
+    // RESULT
+    logic [ZVBC_OP_W-1:0] result;
+    always_comb begin
+        result = DONT_CARE_ZERO ? '0 : 'x;
+        unique case (stage[PIPELINE_STAGES-2].ctrl.mode.zvbc.op)
+            ZVBC_VCLMUL: 
+                unique case (stage[PIPELINE_STAGES-2].ctrl.eew)
+                    VSEW_8: begin
+                        for (int i=0; i < ZVBC_OP_W/8; i++) begin
+                            result[8*i +: 8] = cmul[16*i +: 8];
+                        end
+                    end
+                    VSEW_16: begin
+                        for (int i=0; i < ZVBC_OP_W/16; i++) begin
+                            result[16*i +: 16] = cmul[32*i +: 16];
+                        end
+                    end
+                    VSEW_32: begin
+                        for (int i=0; i < ZVBC_OP_W/32; i++) begin
+                            result[32*i +: 32] = cmul[64*i +: 32];
+                        end
+                    end 
+                    default: ;
+                endcase
+            ZVBC_VCLMULH: 
+                unique case (stage[PIPELINE_STAGES-2].ctrl.eew)
+                    VSEW_8: begin
+                        for (int i=0; i < ZVBC_OP_W/8; i++) begin
+                            result[8*i +: 8] = cmul[16*i+8 +: 8];
+                        end
+                    end
+                    VSEW_16: begin
+                        for (int i=0; i < ZVBC_OP_W/16; i++) begin
+                            result[16*i +: 16] = cmul[32*i+16 +: 16];
+                        end
+                    end
+                    VSEW_32: begin
+                        for (int i=0; i < ZVBC_OP_W/32; i++) begin
+                            result[32*i +: 32] = cmul[64*i+32 +: 32];
+                        end
+                    end 
+                    default: ;
+                endcase
+            default: ;
+        endcase
+    end
+    // RESULT END
+    ///////////////////////////////////////////////////////////////////////////
+
+
+endmodule


### PR DESCRIPTION
It should pass all the respective [riscv-vector-tests](https://github.com/chipsalliance/riscv-vector-tests) for the Zvbb extension.

For the Zvbc extension no unit test are avaliable, since it is only defined for SEW=64. This implementation only supports SEW 8,16 and 32. Manual test where done to ensure correct operation. Custom unit tests will be provided in the future. 