### PR TITLE
rtl: fix vslide1down.vx instruction

### DIFF
--- a/rtl/vproc_sld.sv
+++ b/rtl/vproc_sld.sv
@@ -219,7 +219,7 @@ module vproc_sld #(
                 result_mask_d[i]        = state_ex_q.alt_count_valid;
             end
 
-            if(state_ex_q.mode.sld.dir == SLD_DOWN) begin
+            if(state_ex_q.mode.sld.dir == SLD_DOWN && !state_ex_q.mode.sld.slide1) begin
                 if(state_ex_q.vl_idx[i] + state_ex_q.op_xval >= state_ex_q.vlmax | state_ex_q.op_xval > state_ex_q.vlmax) begin
                     result_d     [i*8 +: 8] = '0;
                     result_mask_d[i] = 1;


### PR DESCRIPTION
Failing tests before fix:
’’’sh
	705 - vslide1down_vx-0 (Failed)
	706 - vslide1down_vx-1 (Failed)
	707 - vslide1down_vx-2 (Failed)
	708 - vslide1down_vx-3 (Failed)
	709 - vslide1down_vx-4 (Failed)
’’’

After PR:
’’’sh
          Start  705: vslide1down_vx-0
 705/1110 Test  #705: vslide1down_vx-0 .................   Passed    0.25 sec
          Start  706: vslide1down_vx-1
 706/1110 Test  #706: vslide1down_vx-1 .................   Passed    0.29 sec
          Start  707: vslide1down_vx-2
 707/1110 Test  #707: vslide1down_vx-2 .................   Passed    0.57 sec
          Start  708: vslide1down_vx-3
 708/1110 Test  #708: vslide1down_vx-3 .................***Failed    1.19 sec
’’’